### PR TITLE
Add IsSafe property to SafetyMonitor DeviceState with proper Rust naming

### DIFF
--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -244,6 +244,7 @@ macro_rules! rpc_trait {
     )*) => {
         /// An object representing all operational properties of the device.
         #[derive(Default, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "PascalCase")]
         #[allow(clippy::unsafe_derive_deserialize)] // seems to be false positive
         pub struct DeviceState {
             $(


### PR DESCRIPTION
I am experimenting with a SafetyMonitor device here: https://github.com/ivonnyssen/rusty-photon

nice work on integrating the conformU checks. I have added a github workflow for these. As part of that I am getting errors because the is_safe property should be named IsSafe in the DeviceState api. The change to the macro below fixes these errors, but I have not done much experimentation across the rest of the crate to see if there are any unintended consequences. Perhaps there is a better way to fix this...

- Add device_state parameter to SafetyMonitor is_safe method
- Implement serde rename_all PascalCase for automatic field conversion
- Maintain Rust snake_case conventions while ensuring ASCOM JSON compliance
- DeviceState now properly serializes is_safe field as IsSafe in API responses