### PR TITLE
Feature/conformu settings file

### DIFF
--- a/src/api/switch.rs
+++ b/src/api/switch.rs
@@ -61,6 +61,15 @@ pub trait Switch: Device + Send + Sync {
     #[http("maxswitchvalue", method = Get)]
     async fn max_switch_value(&self, #[http("Id")] id: usize) -> ASCOMResult<f64>;
 
+    /// Cancels an in-progress asynchronous state change operation.
+    ///
+    /// _ISwitchV3 and later._
+    #[http("cancelasync", method = Put)]
+    async fn cancel_async(&self, #[http("Id")] id: usize) -> ASCOMResult<()> {
+        let _ = id;
+        Err(ASCOMError::NOT_IMPLEMENTED)
+    }
+
     /// This is an asynchronous method that must return as soon as the state change operation has been successfully started,  with StateChangeComplete(Int16) for the given switch Id = False.  After the state change has completed StateChangeComplete(Int16) becomes True.
     ///
     /// _ISwitchV3 and later._

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -24,6 +24,12 @@ pub(crate) enum Error {
         #[source]
         err: serde_plain::Error,
     },
+    #[error("Parameter {name:?} value {value} is out of range for {target_type}")]
+    ParameterOutOfRange {
+        name: &'static str,
+        value: i32,
+        target_type: &'static str,
+    },
     #[error(transparent)]
     Ascom(#[from] ASCOMError),
 }
@@ -32,7 +38,9 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let code = match self {
             Self::UnknownDeviceNumber { .. } | Self::UnknownAction { .. } => StatusCode::NOT_FOUND,
-            Self::MissingParameter { .. } | Self::BadParameter { .. } => StatusCode::BAD_REQUEST,
+            Self::MissingParameter { .. }
+            | Self::BadParameter { .. }
+            | Self::ParameterOutOfRange { .. } => StatusCode::BAD_REQUEST,
             Self::Ascom(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (code, format!("{self:#}")).into_response()

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -31,8 +31,20 @@ where
         &mut self,
         name: &'static str,
     ) -> super::Result<Option<T>> {
-        self.0
-            .swap_remove(name.as_ref())
+        let value_opt = self.0.swap_remove(name.as_ref());
+
+        // Specialization: indices should return InvalidValue for negatives.
+        if let Some(ref value) = value_opt
+            && (TypeId::of::<T>() == TypeId::of::<usize>())
+            && value.trim_start().starts_with('-')
+        {
+            return Err(crate::ASCOMError::invalid_value(format!(
+                "Parameter {name:?} must be non-negative, got: {value}"
+            ))
+            .into());
+        }
+
+        value_opt
             .map(|mut value| {
                 // Specialization: optimized path to avoid cloning the string.
                 if TypeId::of::<T>() == TypeId::of::<String>() {

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -16,7 +16,10 @@ enum AlpacaParseError {
     /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
     BadFormat(String),
     /// Valid i32 but out of range for target type -> `INVALID_VALUE` (ASCOM error)
-    OutOfRange { value: i32, target_type: &'static str },
+    OutOfRange {
+        value: i32,
+        target_type: &'static str,
+    },
 }
 
 impl fmt::Display for AlpacaParseError {
@@ -268,11 +271,13 @@ where
             .swap_remove(name.as_ref())
             .map(|value| {
                 T::deserialize(AlpacaDeserializer { value }).map_err(|err| match err {
-                    AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
-                        name,
-                        value,
-                        target_type,
-                    },
+                    AlpacaParseError::OutOfRange { value, target_type } => {
+                        Error::ParameterOutOfRange {
+                            name,
+                            value,
+                            target_type,
+                        }
+                    }
                     AlpacaParseError::BadFormat(msg) => Error::BadParameter {
                         name,
                         err: serde_plain::Error::custom(msg),
@@ -282,10 +287,7 @@ where
             .transpose()
     }
 
-    pub(crate) fn extract<T: DeserializeOwned>(
-        &mut self,
-        name: &'static str,
-    ) -> super::Result<T> {
+    pub(crate) fn extract<T: DeserializeOwned>(&mut self, name: &'static str) -> super::Result<T> {
         self.maybe_extract(name)?
             .ok_or(Error::MissingParameter { name })
     }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -6,10 +6,243 @@ use axum::response::{IntoResponse, Response};
 use http::{Method, StatusCode};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde::de::{DeserializeOwned, IntoDeserializer};
-use std::any::TypeId;
-use std::fmt::Debug;
+use serde::de::{DeserializeOwned, Deserializer, Error as _, Visitor};
+use std::fmt::{self, Debug};
 use std::hash::Hash;
+
+/// Error type for ALPACA parameter parsing that distinguishes parse errors from range errors.
+#[derive(Debug)]
+enum AlpacaParseError {
+    /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
+    BadFormat(String),
+    /// Valid i32 but out of range for target type -> `INVALID_VALUE` (ASCOM error)
+    OutOfRange { value: i32, target_type: &'static str },
+}
+
+impl fmt::Display for AlpacaParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadFormat(msg) => write!(f, "{msg}"),
+            Self::OutOfRange { value, target_type } => {
+                write!(f, "value {value} is out of range for {target_type}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AlpacaParseError {}
+
+impl serde::de::Error for AlpacaParseError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::BadFormat(msg.to_string())
+    }
+}
+
+/// Custom serde Deserializer for ALPACA parameters.
+///
+/// Per ASCOM spec, integers are transmitted as i32, so we parse as i32 first
+/// then convert to the target type. This allows distinguishing parse errors
+/// (`BadParameter`) from range errors (`INVALID_VALUE`).
+struct AlpacaDeserializer {
+    value: String,
+}
+
+impl AlpacaDeserializer {
+    /// Parse an integer per ALPACA spec: parse as i32, then convert to target type.
+    fn parse_integer<T: TryFrom<i32>>(&self) -> Result<T, AlpacaParseError> {
+        let i32_value: i32 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
+        })?;
+
+        T::try_from(i32_value).map_err(|_range_err| AlpacaParseError::OutOfRange {
+            value: i32_value,
+            target_type: std::any::type_name::<T>(),
+        })
+    }
+}
+
+impl<'de> Deserializer<'de> for AlpacaDeserializer {
+    type Error = AlpacaParseError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value.trim().to_ascii_lowercase().as_str() {
+            "true" => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            _ => Err(AlpacaParseError::BadFormat(format!(
+                "invalid boolean: {}",
+                self.value
+            ))),
+        }
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i8(self.parse_integer()?)
+    }
+
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i16(self.parse_integer()?)
+    }
+
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i32(self.parse_integer()?)
+    }
+
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(self.parse_integer()?)
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u8(self.parse_integer()?)
+    }
+
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u16(self.parse_integer()?)
+    }
+
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u32(self.parse_integer()?)
+    }
+
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(self.parse_integer()?)
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let value: f32 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+        })?;
+        visitor.visit_f32(value)
+    }
+
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let value: f64 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+        })?;
+        visitor.visit_f64(value)
+    }
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let mut chars = self.value.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) => visitor.visit_char(c),
+            _ => Err(AlpacaParseError::BadFormat(format!(
+                "expected single character: {}",
+                self.value
+            ))),
+        }
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_bytes(self.value.as_bytes())
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_byte_buf(self.value.into_bytes())
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_enum(serde::de::value::StringDeserializer::new(self.value))
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "Option types are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "unit type is not supported as ALPACA parameter".to_owned(),
+        ))
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "unit struct is not supported as ALPACA parameter".to_owned(),
+        ))
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "sequences are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "tuples are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "tuple structs are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "maps are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "structs are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+}
 
 #[derive(Deserialize, derive_more::Debug)]
 #[debug("{_0:?}")]
@@ -27,40 +260,29 @@ impl<ParamStr: ?Sized + Hash + Eq + Debug> OpaqueParams<ParamStr>
 where
     str: AsRef<ParamStr>,
 {
-    pub(crate) fn maybe_extract<T: 'static + DeserializeOwned>(
+    pub(crate) fn maybe_extract<T: DeserializeOwned>(
         &mut self,
         name: &'static str,
     ) -> super::Result<Option<T>> {
-        let value_opt = self.0.swap_remove(name.as_ref());
-
-        // Specialization: indices should return InvalidValue for negatives.
-        if let Some(ref value) = value_opt
-            && (TypeId::of::<T>() == TypeId::of::<usize>())
-            && value.trim_start().starts_with('-')
-        {
-            return Err(crate::ASCOMError::invalid_value(format!(
-                "Parameter {name:?} must be non-negative, got: {value}"
-            ))
-            .into());
-        }
-
-        value_opt
-            .map(|mut value| {
-                // Specialization: optimized path to avoid cloning the string.
-                if TypeId::of::<T>() == TypeId::of::<String>() {
-                    return T::deserialize(value.into_deserializer());
-                }
-                // Specialization: booleans in ASCOM must be case-insensitive.
-                if TypeId::of::<T>() == TypeId::of::<bool>() {
-                    value.make_ascii_lowercase();
-                }
-                serde_plain::from_str(&value)
+        self.0
+            .swap_remove(name.as_ref())
+            .map(|value| {
+                T::deserialize(AlpacaDeserializer { value }).map_err(|err| match err {
+                    AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
+                        name,
+                        value,
+                        target_type,
+                    },
+                    AlpacaParseError::BadFormat(msg) => Error::BadParameter {
+                        name,
+                        err: serde_plain::Error::custom(msg),
+                    },
+                })
             })
             .transpose()
-            .map_err(|err| Error::BadParameter { name, err })
     }
 
-    pub(crate) fn extract<T: 'static + DeserializeOwned>(
+    pub(crate) fn extract<T: DeserializeOwned>(
         &mut self,
         name: &'static str,
     ) -> super::Result<T> {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -52,6 +52,13 @@ where
         match self.response {
             Ok(response) => Ok(Ok(response)),
             Err(Error::Ascom(err)) => Ok(Err(err)),
+            Err(Error::ParameterOutOfRange {
+                name,
+                value,
+                target_type,
+            }) => Ok(Err(ASCOMError::invalid_value(format!(
+                "Parameter {name:?} value {value} is out of range for {target_type}"
+            )))),
             Err(err @ (Error::MissingParameter { .. } | Error::BadParameter { .. })) => {
                 Err((StatusCode::BAD_REQUEST, err.to_string()))
             }

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -1,6 +1,7 @@
 use crate::api::RetrieavableDevice;
 use reqwest::{IntoUrl, Url};
 use std::fmt::Debug;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -23,11 +24,20 @@ impl ConformU {
     }
 
     /// Run the specified test with ConformU against the specified device URL.
-    #[tracing::instrument(level = "error", skip(device_url))]
-    async fn test(self, device_url: &Url) -> eyre::Result<()> {
+    #[tracing::instrument(level = "error", skip(device_url, settings_file))]
+    async fn test(self, device_url: &Url, settings_file: Option<&Path>) -> eyre::Result<()> {
+        use std::ffi::OsString;
+
+        // Build args list - must be done before cmd! macro to avoid borrow issues
+        let mut args: Vec<OsString> = vec![self.as_arg().into()];
+        if let Some(path) = settings_file {
+            args.push("--settingsfile".into());
+            args.push(path.into());
+        }
+        args.push(device_url.as_str().into());
+
         let mut conformu = cmd!(r"C:\Program Files\ASCOM\ConformU", "conformu")
-            .arg(self.as_arg())
-            .arg(device_url.as_str())
+            .args(&args)
             .stdout(Stdio::piped())
             .spawn()?;
 
@@ -151,21 +161,86 @@ fn split_with_whitespace<'line>(line: &mut &'line str, len: usize) -> Option<&'l
     Some(part)
 }
 
+/// Builder for configuring and running ConformU tests.
+///
+/// Created via [`conformu_tests`].
+#[derive(Debug)]
+pub struct ConformUTestBuilder {
+    device_url: Url,
+    settings_file: Option<PathBuf>,
+}
+
+impl ConformUTestBuilder {
+    /// Create a new builder for testing a device at the specified URL.
+    fn new(device_url: Url) -> Self {
+        Self {
+            device_url,
+            settings_file: None,
+        }
+    }
+
+    /// Set a custom ConformU settings file.
+    ///
+    /// This can be used to configure test parameters like `SwitchReadDelay`
+    /// and `SwitchWriteDelay` to speed up CI test runs.
+    pub fn settings_file(mut self, path: impl AsRef<Path>) -> Self {
+        self.settings_file = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Run all ConformU tests (AlpacaProtocol and Conformance).
+    #[tracing::instrument(level = "error", skip(self))]
+    pub async fn run(self) -> eyre::Result<()> {
+        // Must be executed serially as they operate on the same device.
+        ConformU::AlpacaProtocol
+            .test(&self.device_url, self.settings_file.as_deref())
+            .await?;
+        ConformU::Conformance
+            .test(&self.device_url, self.settings_file.as_deref())
+            .await
+    }
+}
+
+/// Create a builder for running ConformU tests against the device at the specified URL.
+///
+/// This assumes that ConformU is installed and available on PATH or in the
+/// default installation location.
+///
+/// # Example
+///
+/// ```ignore
+/// // Run with default settings
+/// conformu_tests::<dyn Switch>(server_url, 0)?.run().await?;
+///
+/// // Run with custom settings file for faster CI
+/// conformu_tests::<dyn Switch>(server_url, 0)?
+///     .settings_file("conformu-fast.json")
+///     .run()
+///     .await?;
+/// ```
+#[allow(private_bounds)]
+pub fn conformu_tests<T: ?Sized + RetrieavableDevice>(
+    server_url: impl IntoUrl + Debug,
+    device_number: usize,
+) -> eyre::Result<ConformUTestBuilder> {
+    let url = server_url
+        .into_url()?
+        .join(&format!("api/v1/{ty}/{device_number}", ty = T::TYPE))?;
+
+    Ok(ConformUTestBuilder::new(url))
+}
+
 /// Run all the ConformU tests against the device at the specified URL.
 ///
 /// This assumes that ConformU is installed and available on PATH or in the
 /// default installation location.
+///
+/// For more configuration options, use [`conformu_tests`] to get a builder.
 #[tracing::instrument(level = "error", fields(ty = ?T::TYPE))]
 #[allow(private_bounds)]
 pub async fn run_conformu_tests<T: ?Sized + RetrieavableDevice>(
     server_url: impl IntoUrl + Debug,
     device_number: usize,
 ) -> eyre::Result<()> {
-    let url = server_url
-        .into_url()?
-        .join(&format!("api/v1/{ty}/{device_number}", ty = T::TYPE))?;
-
-    // Must be executed serially as they operate on the same device.
-    ConformU::AlpacaProtocol.test(&url).await?;
-    ConformU::Conformance.test(&url).await
+    conformu_tests::<T>(server_url, device_number)?.run().await
 }

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -172,7 +172,7 @@ pub struct ConformUTestBuilder {
 
 impl ConformUTestBuilder {
     /// Create a new builder for testing a device at the specified URL.
-    fn new(device_url: Url) -> Self {
+    const fn new(device_url: Url) -> Self {
         Self {
             device_url,
             settings_file: None,
@@ -219,12 +219,13 @@ impl ConformUTestBuilder {
     ///     .run()
     ///     .await?;
     /// ```
+    #[must_use]
     pub fn settings_file(mut self, path: impl AsRef<Path>) -> Self {
         self.settings_file = Some(path.as_ref().to_path_buf());
         self
     }
 
-    /// Run all ConformU tests (AlpacaProtocol and Conformance).
+    /// Run all ConformU tests (`AlpacaProtocol` and `Conformance`).
     #[tracing::instrument(level = "error", skip(self))]
     pub async fn run(self) -> eyre::Result<()> {
         // Must be executed serially as they operate on the same device.

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -181,8 +181,44 @@ impl ConformUTestBuilder {
 
     /// Set a custom ConformU settings file.
     ///
-    /// This can be used to configure test parameters like `SwitchReadDelay`
-    /// and `SwitchWriteDelay` to speed up CI test runs.
+    /// # Important: Complete Settings File Required
+    ///
+    /// ConformU requires a **complete** settings file with all properties.
+    /// Partial files containing only a few settings will be silently ignored
+    /// and overwritten with defaults.
+    ///
+    /// ## Generating a Default Settings Template
+    ///
+    /// To generate a complete settings file with all default values, run ConformU
+    /// with an empty JSON object file. ConformU will populate it with all defaults:
+    ///
+    /// ```bash
+    /// echo "{}" > conformu-settings.json
+    /// conformu conformance --settingsfile conformu-settings.json http://localhost:99999/api/v1/switch/0
+    /// # The command will fail (no server), but conformu-settings.json now has all defaults
+    /// ```
+    ///
+    /// You can then edit the generated file to customize specific values
+    /// (e.g., reduce `SwitchReadDelay` and `SwitchWriteDelay` for faster CI).
+    ///
+    /// ## Switch Testing Performance
+    ///
+    /// For Switch device tests, the default delays are:
+    /// - `SwitchReadDelay`: 500ms
+    /// - `SwitchWriteDelay`: 3000ms
+    ///
+    /// For CI environments, reducing these (e.g., to 50ms and 100ms) can cut test
+    /// time from ~8 minutes to ~35 seconds.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Use a pre-configured settings file with reduced delays
+    /// conformu_tests::<dyn Switch>(server_url, 0)?
+    ///     .settings_file("test-fixtures/conformu-settings.json")
+    ///     .run()
+    ///     .await?;
+    /// ```
     pub fn settings_file(mut self, path: impl AsRef<Path>) -> Self {
         self.settings_file = Some(path.as_ref().to_path_buf());
         self
@@ -213,8 +249,9 @@ impl ConformUTestBuilder {
 /// conformu_tests::<dyn Switch>(server_url, 0)?.run().await?;
 ///
 /// // Run with custom settings file for faster CI
+/// // Note: ConformU requires a COMPLETE settings file - see settings_file() docs
 /// conformu_tests::<dyn Switch>(server_url, 0)?
-///     .settings_file("conformu-fast.json")
+///     .settings_file("test-fixtures/conformu-settings.json")
 ///     .run()
 ///     .await?;
 /// ```

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -7,7 +7,7 @@ mod logging_env;
 pub use crate::client::test::get_simulator_devices;
 
 #[cfg(feature = "server")]
-pub use crate::server::test::run_conformu_tests;
+pub use crate::server::test::{conformu_tests, run_conformu_tests, ConformUTestBuilder};
 
 pub(crate) fn resolve_path(path_hint: &'static str, exe_name: &'static str) -> PathBuf {
     use std::env;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -7,7 +7,7 @@ mod logging_env;
 pub use crate::client::test::get_simulator_devices;
 
 #[cfg(feature = "server")]
-pub use crate::server::test::{conformu_tests, run_conformu_tests, ConformUTestBuilder};
+pub use crate::server::test::{ConformUTestBuilder, conformu_tests, run_conformu_tests};
 
 pub(crate) fn resolve_path(path_hint: &'static str, exe_name: &'static str) -> PathBuf {
     use std::env;


### PR DESCRIPTION
This is another incremental PR. Perhaps we should sort through separately. When I created a switch driver, I found that conformU has default delays in place 5000ms on read and 3000ms on write between tests. This means CI tests with these default settings run over 10 minutes. ConformU also has the ability to take a settings file. This PR adds that capability using a builder pattern to be backwards compatible.