### PR TITLE
Add cancel_async method to Switch trait

### DIFF
--- a/src/api/switch.rs
+++ b/src/api/switch.rs
@@ -66,7 +66,6 @@ pub trait Switch: Device + Send + Sync {
     /// _ISwitchV3 and later._
     #[http("cancelasync", method = Put)]
     async fn cancel_async(&self, #[http("Id")] id: usize) -> ASCOMResult<()> {
-        let _ = id;
         Err(ASCOMError::NOT_IMPLEMENTED)
     }
 

--- a/src/api/switch.rs
+++ b/src/api/switch.rs
@@ -61,6 +61,15 @@ pub trait Switch: Device + Send + Sync {
     #[http("maxswitchvalue", method = Get)]
     async fn max_switch_value(&self, #[http("Id")] id: usize) -> ASCOMResult<f64>;
 
+    /// Cancels an in-progress asynchronous state change operation.
+    ///
+    /// _ISwitchV3 and later._
+    #[http("cancelasync", method = Put)]
+    async fn cancel_async(&self, #[http("Id")] id: usize) -> ASCOMResult<()> {
+        let _ = id;
+        Err(ASCOMError::NOT_IMPLEMENTED)
+    }
+
     /// This is an asynchronous method that must return as soon as the state change operation has been successfully started,  with StateChangeComplete(Int16) for the given switch Id = False.  After the state change has completed StateChangeComplete(Int16) becomes True.
     ///
     /// _ISwitchV3 and later._


### PR DESCRIPTION
## Summary

Adds the missing `cancel_async` method to the `Switch` trait for ISwitchV3 compliance. The method follows the same pattern as the existing `set_async` and `set_async_value` methods — default implementation returns `NOT_IMPLEMENTED`.

## Motivation

The ISwitchV3 specification defines `CancelAsync` as a required method, but the trait currently only has `set_async`, `set_async_value`, and `state_change_complete`. Adding `cancel_async` completes the ISwitchV3 surface and allows implementations to pass ConformU conformance testing for switches with async operations.

## Changes

- `src/api/switch.rs`: Added `cancel_async(&self, id: usize) -> ASCOMResult<()>` with `#[http("cancelasync", method = Put)]` attribute and default `NOT_IMPLEMENTED` implementation.

## Test plan

- [x] `cargo clippy` passes (full CI feature matrix verified)
- [ ] Existing switch tests continue to pass
- [ ] Method signature matches [ASCOM ISwitchV3 spec](https://ascom-standards.org/api/#/Switch%20Specific%20Methods/put_switch__device_number__cancelasync)