### PR TITLE
Add Client::new_with_client() for custom reqwest::Client

### DIFF
--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -48,7 +48,7 @@ macro_rules! rpc_trait {
         fn setup(&self) -> futures::future::BoxFuture<'_, eyre::Result<String>> {
             Box::pin(async move {
                 Ok(
-                    $crate::client::REQWEST
+                    self.inner.http
                         .get(self.inner.base_url.join("setup")?)
                         .send()
                         .await?

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -73,10 +73,6 @@ pub(crate) struct RawClient {
 }
 
 impl RawClient {
-    pub(crate) fn new(base_url: reqwest::Url) -> eyre::Result<Self> {
-        Self::new_with_client(base_url, REQWEST.clone())
-    }
-
     pub(crate) fn new_with_client(
         base_url: reqwest::Url,
         http: reqwest::Client,
@@ -185,7 +181,7 @@ pub struct Client {
 impl Client {
     /// Create a new client with given server URL.
     pub fn new(base_url: impl IntoUrl) -> eyre::Result<Self> {
-        RawClient::new(base_url.into_url()?).map(|inner| Self { inner })
+        RawClient::new_with_client(base_url.into_url()?, REQWEST.clone()).map(|inner| Self { inner })
     }
 
     /// Create a new client with a caller-provided [`reqwest::Client`].

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -68,10 +68,19 @@ pub(crate) struct RawClient {
     #[debug(r#""{base_url}""#)]
     pub(crate) base_url: reqwest::Url,
     pub(crate) client_id: NonZeroU32,
+    #[debug(skip)]
+    pub(crate) http: reqwest::Client,
 }
 
 impl RawClient {
     pub(crate) fn new(base_url: reqwest::Url) -> eyre::Result<Self> {
+        Self::new_with_client(base_url, REQWEST.clone())
+    }
+
+    pub(crate) fn new_with_client(
+        base_url: reqwest::Url,
+        http: reqwest::Client,
+    ) -> eyre::Result<Self> {
         eyre::ensure!(
             !base_url.cannot_be_a_base(),
             "{} is not a valid base URL",
@@ -80,6 +89,7 @@ impl RawClient {
         Ok(Self {
             base_url,
             client_id: rand::random(),
+            http,
         })
     }
 
@@ -103,7 +113,7 @@ impl RawClient {
         async move {
             tracing::debug!(?method, params = ?serdebug::debug(&params), base_url = %self.base_url, "Sending request");
 
-            let mut request = REQWEST.request(method.into(), self.base_url.join(action)?);
+            let mut request = self.http.request(method.into(), self.base_url.join(action)?);
 
             let add_params = match method {
                 Method::Get => RequestBuilder::query,
@@ -161,6 +171,7 @@ impl RawClient {
         Ok(Self {
             base_url: self.base_url.join(path)?,
             client_id: self.client_id,
+            http: self.http.clone(),
         })
     }
 }
@@ -175,6 +186,15 @@ impl Client {
     /// Create a new client with given server URL.
     pub fn new(base_url: impl IntoUrl) -> eyre::Result<Self> {
         RawClient::new(base_url.into_url()?).map(|inner| Self { inner })
+    }
+
+    /// Create a new client with a caller-provided [`reqwest::Client`].
+    ///
+    /// This allows injecting a custom HTTP client configured with TLS CA
+    /// trust, HTTP Basic Auth default headers, or other settings that the
+    /// default client does not provide.
+    pub fn new_with_client(base_url: impl IntoUrl, client: reqwest::Client) -> eyre::Result<Self> {
+        RawClient::new_with_client(base_url.into_url()?, client).map(|inner| Self { inner })
     }
 
     /// Create a new client with given server address.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -181,7 +181,7 @@ pub struct Client {
 impl Client {
     /// Create a new client with given server URL.
     pub fn new(base_url: impl IntoUrl) -> eyre::Result<Self> {
-        RawClient::new_with_client(base_url.into_url()?, REQWEST.clone()).map(|inner| Self { inner })
+        Self::new_with_client(base_url, REQWEST.clone())
     }
 
     /// Create a new client with a caller-provided [`reqwest::Client`].
@@ -244,5 +244,53 @@ impl Client {
             })
             .await
             .map(|value_response| value_response.value)
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_with_client_uses_injected_http_client() -> eyre::Result<()> {
+        let app = axum::Router::new().fallback(|req: axum::extract::Request| async move {
+            let custom_value = req
+                .headers()
+                .get("X-Custom-Test")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_owned();
+
+            axum::Json(serde_json::json!({
+                "ServerTransactionID": 1_u32,
+                "ErrorNumber": 0_u32,
+                "ErrorMessage": "",
+                "Value": {
+                    "ServerName": custom_value,
+                    "Manufacturer": "test",
+                    "ManufacturerVersion": "1.0",
+                    "Location": "test"
+                }
+            }))
+        });
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let _server = tokio::spawn(axum::serve(listener, app).into_future());
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        let _ = headers.insert("X-Custom-Test", "injected-client".parse()?);
+        let custom = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+
+        let client = Client::new_with_client(format!("http://{addr}/"), custom)?;
+        let info = client.get_server_info().await?;
+        eyre::ensure!(
+            &*info.server_name == "injected-client",
+            "expected server to echo custom header, got {:?}",
+            info.server_name,
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Adds `Client::new_with_client(base_url, reqwest::Client)` as a companion to the existing `Client::new(base_url)`, allowing callers to inject a pre-configured `reqwest::Client`.

## Motivation

When connecting to an Alpaca server behind TLS with a private CA, the default `reqwest::Client` rejects the certificate. Callers need to inject a client configured with `.add_root_certificate(ca)`. Similarly, servers requiring HTTP Basic Auth need default headers set on the client. There is currently no way to customize the HTTP client used by the Alpaca `Client`.

## Changes

- `src/client/mod.rs`:
  - Added `http: reqwest::Client` field to `RawClient`
  - Added `RawClient::new_with_client()` constructor; `Client::new()` delegates to `Client::new_with_client()` with the default global client
  - Changed `request()` to use `self.http` instead of the global `REQWEST` static
  - Added public `Client::new_with_client()` that wraps the raw client constructor
  - Updated `join_url()` to clone the `http` field
  - Added test verifying the injected client is used for requests

- `src/api/macros.rs`:
  - Fixed `Device::setup()` to use `self.inner.http` instead of the global `REQWEST` static, ensuring custom TLS/auth configuration is applied to setup requests

## Test plan

- [x] `cargo clippy` passes (full CI feature matrix verified)
- [x] New test verifies injected `reqwest::Client` is used for requests
- [ ] Existing client tests continue to pass
- [ ] `Client::new()` behavior is unchanged (uses default client)
- [ ] No breaking changes — new additive API only