### PR TITLE
Return ASCOM INVALID_VALUE for out-of-range integer parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,6 @@ dependencies = [
  "serde",
  "serde-ndim",
  "serde_json",
- "serde_plain",
  "serde_repr",
  "serdebug",
  "socket2",
@@ -4174,15 +4173,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_plain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ reqwest = { version = "0.13.1", optional = true, default-features = false, featu
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde-ndim = { version = "2.2.0", optional = true, features = ["ndarray"] }
 serde_json = { version = "1.0.148" }
-serde_plain = { version = "1.0.2", optional = true }
 serde_repr = "0.1.20"
 socket2 = "0.6.1"
 thiserror = "2.0.17"
@@ -155,7 +154,6 @@ server = [
 	"dep:http-body",
 	"dep:http-body-util",
 	"dep:indexmap",
-	"dep:serde_plain",
 	"dep:tower-service",
 ]
 

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -24,6 +24,12 @@ pub(crate) enum Error {
         #[source]
         err: serde_plain::Error,
     },
+    #[error("Parameter {name:?} value {value} is out of range for {target_type}")]
+    ParameterOutOfRange {
+        name: &'static str,
+        value: i32,
+        target_type: &'static str,
+    },
     #[error(transparent)]
     Ascom(#[from] ASCOMError),
 }
@@ -32,7 +38,9 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let code = match self {
             Self::UnknownDeviceNumber { .. } | Self::UnknownAction { .. } => StatusCode::NOT_FOUND,
-            Self::MissingParameter { .. } | Self::BadParameter { .. } => StatusCode::BAD_REQUEST,
+            Self::MissingParameter { .. }
+            | Self::BadParameter { .. }
+            | Self::ParameterOutOfRange { .. } => StatusCode::BAD_REQUEST,
             Self::Ascom(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (code, format!("{self:#}")).into_response()

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,3 +1,4 @@
+use super::params::AlpacaParseError;
 use crate::ASCOMError;
 use crate::api::DeviceType;
 use axum::http::StatusCode;
@@ -22,13 +23,7 @@ pub(crate) enum Error {
     BadParameter {
         name: &'static str,
         #[source]
-        err: serde_plain::Error,
-    },
-    #[error("Parameter {name:?} value {value} is out of range for {target_type}")]
-    ParameterOutOfRange {
-        name: &'static str,
-        value: i64,
-        target_type: &'static str,
+        err: AlpacaParseError,
     },
     #[error(transparent)]
     Ascom(#[from] ASCOMError),
@@ -38,9 +33,7 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let code = match self {
             Self::UnknownDeviceNumber { .. } | Self::UnknownAction { .. } => StatusCode::NOT_FOUND,
-            Self::MissingParameter { .. }
-            | Self::BadParameter { .. }
-            | Self::ParameterOutOfRange { .. } => StatusCode::BAD_REQUEST,
+            Self::MissingParameter { .. } | Self::BadParameter { .. } => StatusCode::BAD_REQUEST,
             Self::Ascom(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (code, format!("{self:#}")).into_response()

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -27,7 +27,7 @@ pub(crate) enum Error {
     #[error("Parameter {name:?} value {value} is out of range for {target_type}")]
     ParameterOutOfRange {
         name: &'static str,
-        value: i32,
+        value: i64,
         target_type: &'static str,
     },
     #[error(transparent)]

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -6,31 +6,20 @@ use axum::response::{IntoResponse, Response};
 use http::{Method, StatusCode};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde::de::{DeserializeOwned, Deserializer, Error as _, Visitor};
+use serde::de::{DeserializeOwned, Deserializer, Visitor};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
 /// Error type for Alpaca parameter parsing that distinguishes parse errors from range errors.
-#[derive(Debug)]
-enum AlpacaParseError {
-    /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AlpacaParseError {
+    /// Invalid format (not a valid integer/bool/etc) -> HTTP 400
+    #[error("{0}")]
     BadFormat(String),
-    /// Valid integer but out of range for target type -> `INVALID_VALUE` (ASCOM error)
+    /// Valid integer but out of range for target type -> ASCOM `INVALID_VALUE`
+    #[error("value {value} is out of range for {target_type}")]
     OutOfRange { value: i64, target_type: &'static str },
 }
-
-impl fmt::Display for AlpacaParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::BadFormat(msg) => write!(f, "{msg}"),
-            Self::OutOfRange { value, target_type } => {
-                write!(f, "value {value} is out of range for {target_type}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for AlpacaParseError {}
 
 impl serde::de::Error for AlpacaParseError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
@@ -268,17 +257,8 @@ where
         self.0
             .swap_remove(name.as_ref())
             .map(|value| {
-                T::deserialize(AlpacaDeserializer { value }).map_err(|err| match err {
-                    AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
-                        name,
-                        value,
-                        target_type,
-                    },
-                    AlpacaParseError::BadFormat(msg) => Error::BadParameter {
-                        name,
-                        err: serde_plain::Error::custom(msg),
-                    },
-                })
+                T::deserialize(AlpacaDeserializer { value })
+                    .map_err(|err| Error::BadParameter { name, err })
             })
             .transpose()
     }
@@ -337,17 +317,7 @@ mod tests {
         let deser = AlpacaDeserializer {
             value: value.to_owned(),
         };
-        T::deserialize(deser).map_err(|err| match err {
-            AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
-                name: "test",
-                value,
-                target_type,
-            },
-            AlpacaParseError::BadFormat(msg) => Error::BadParameter {
-                name: "test",
-                err: serde_plain::Error::custom(msg),
-            },
-        })
+        T::deserialize(deser).map_err(|err| Error::BadParameter { name: "test", err })
     }
 
     #[test]
@@ -384,7 +354,13 @@ mod tests {
     fn i32_out_of_range() {
         let err = parse::<i32>("3000000000").expect_err("should fail for i32 out of range");
         assert!(
-            matches!(err, Error::ParameterOutOfRange { .. }),
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::OutOfRange { .. },
+                    ..
+                }
+            ),
             "expected OutOfRange, got: {err:?}"
         );
     }
@@ -393,7 +369,13 @@ mod tests {
     fn u32_negative_out_of_range() {
         let err = parse::<u32>("-1").expect_err("should fail for negative u32");
         assert!(
-            matches!(err, Error::ParameterOutOfRange { .. }),
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::OutOfRange { .. },
+                    ..
+                }
+            ),
             "expected OutOfRange, got: {err:?}"
         );
     }
@@ -402,7 +384,13 @@ mod tests {
     fn u8_out_of_range() {
         let err = parse::<u8>("256").expect_err("should fail for u8 out of range");
         assert!(
-            matches!(err, Error::ParameterOutOfRange { .. }),
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::OutOfRange { .. },
+                    ..
+                }
+            ),
             "expected OutOfRange, got: {err:?}"
         );
     }
@@ -411,8 +399,14 @@ mod tests {
     fn bad_format_non_numeric() {
         let err = parse::<u32>("abc").expect_err("should fail for non-numeric input");
         assert!(
-            matches!(err, Error::BadParameter { .. }),
-            "expected BadParameter, got: {err:?}"
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::BadFormat(_),
+                    ..
+                }
+            ),
+            "expected BadFormat, got: {err:?}"
         );
     }
 

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -10,7 +10,7 @@ use serde::de::{DeserializeOwned, Deserializer, Error as _, Visitor};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-/// Error type for ALPACA parameter parsing that distinguishes parse errors from range errors.
+/// Error type for Alpaca parameter parsing that distinguishes parse errors from range errors.
 #[derive(Debug)]
 enum AlpacaParseError {
     /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
@@ -38,7 +38,7 @@ impl serde::de::Error for AlpacaParseError {
     }
 }
 
-/// Custom serde Deserializer for ALPACA parameters.
+/// Custom serde Deserializer for Alpaca parameters.
 ///
 /// Integers are parsed as i64 first, then converted to the target type.
 /// This allows distinguishing parse errors (`BadParameter`) from range errors
@@ -180,13 +180,13 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
 
     fn deserialize_option<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "Option types are not supported as ALPACA parameters".to_owned(),
+            "Option types are not supported as Alpaca parameters".to_owned(),
         ))
     }
 
     fn deserialize_unit<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "unit type is not supported as ALPACA parameter".to_owned(),
+            "unit type is not supported as Alpaca parameter".to_owned(),
         ))
     }
 
@@ -196,13 +196,13 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "unit struct is not supported as ALPACA parameter".to_owned(),
+            "unit struct is not supported as Alpaca parameter".to_owned(),
         ))
     }
 
     fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "sequences are not supported as ALPACA parameters".to_owned(),
+            "sequences are not supported as Alpaca parameters".to_owned(),
         ))
     }
 
@@ -212,7 +212,7 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "tuples are not supported as ALPACA parameters".to_owned(),
+            "tuples are not supported as Alpaca parameters".to_owned(),
         ))
     }
 
@@ -223,13 +223,13 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "tuple structs are not supported as ALPACA parameters".to_owned(),
+            "tuple structs are not supported as Alpaca parameters".to_owned(),
         ))
     }
 
     fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "maps are not supported as ALPACA parameters".to_owned(),
+            "maps are not supported as Alpaca parameters".to_owned(),
         ))
     }
 
@@ -240,7 +240,7 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
         Err(AlpacaParseError::BadFormat(
-            "structs are not supported as ALPACA parameters".to_owned(),
+            "structs are not supported as Alpaca parameters".to_owned(),
         ))
     }
 }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -31,8 +31,20 @@ where
         &mut self,
         name: &'static str,
     ) -> super::Result<Option<T>> {
-        self.0
-            .swap_remove(name.as_ref())
+        let value_opt = self.0.swap_remove(name.as_ref());
+
+        // Specialization: indices should return InvalidValue for negatives.
+        if let Some(ref value) = value_opt
+            && (TypeId::of::<T>() == TypeId::of::<usize>())
+            && value.trim_start().starts_with('-')
+        {
+            return Err(crate::ASCOMError::invalid_value(format!(
+                "Parameter {name:?} must be non-negative, got: {value}"
+            ))
+            .into());
+        }
+
+        value_opt
             .map(|mut value| {
                 // Specialization: optimized path to avoid cloning the string.
                 if TypeId::of::<T>() == TypeId::of::<String>() {

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -6,10 +6,243 @@ use axum::response::{IntoResponse, Response};
 use http::{Method, StatusCode};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde::de::{DeserializeOwned, IntoDeserializer};
-use std::any::TypeId;
-use std::fmt::Debug;
+use serde::de::{DeserializeOwned, Deserializer, Error as _, Visitor};
+use std::fmt::{self, Debug};
 use std::hash::Hash;
+
+/// Error type for ALPACA parameter parsing that distinguishes parse errors from range errors.
+#[derive(Debug)]
+enum AlpacaParseError {
+    /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
+    BadFormat(String),
+    /// Valid i32 but out of range for target type -> `INVALID_VALUE` (ASCOM error)
+    OutOfRange { value: i32, target_type: &'static str },
+}
+
+impl fmt::Display for AlpacaParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadFormat(msg) => write!(f, "{msg}"),
+            Self::OutOfRange { value, target_type } => {
+                write!(f, "value {value} is out of range for {target_type}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AlpacaParseError {}
+
+impl serde::de::Error for AlpacaParseError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::BadFormat(msg.to_string())
+    }
+}
+
+/// Custom serde Deserializer for ALPACA parameters.
+///
+/// Per ASCOM spec, integers are transmitted as i32, so we parse as i32 first
+/// then convert to the target type. This allows distinguishing parse errors
+/// (`BadParameter`) from range errors (`INVALID_VALUE`).
+struct AlpacaDeserializer {
+    value: String,
+}
+
+impl AlpacaDeserializer {
+    /// Parse an integer per ALPACA spec: parse as i32, then convert to target type.
+    fn parse_integer<T: TryFrom<i32>>(&self) -> Result<T, AlpacaParseError> {
+        let i32_value: i32 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
+        })?;
+
+        T::try_from(i32_value).map_err(|_range_err| AlpacaParseError::OutOfRange {
+            value: i32_value,
+            target_type: std::any::type_name::<T>(),
+        })
+    }
+}
+
+impl<'de> Deserializer<'de> for AlpacaDeserializer {
+    type Error = AlpacaParseError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value.trim().to_ascii_lowercase().as_str() {
+            "true" => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            _ => Err(AlpacaParseError::BadFormat(format!(
+                "invalid boolean: {}",
+                self.value
+            ))),
+        }
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i8(self.parse_integer()?)
+    }
+
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i16(self.parse_integer()?)
+    }
+
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i32(self.parse_integer()?)
+    }
+
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(self.parse_integer()?)
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u8(self.parse_integer()?)
+    }
+
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u16(self.parse_integer()?)
+    }
+
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u32(self.parse_integer()?)
+    }
+
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(self.parse_integer()?)
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let value: f32 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+        })?;
+        visitor.visit_f32(value)
+    }
+
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let value: f64 = self.value.trim().parse().map_err(|_parse_err| {
+            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+        })?;
+        visitor.visit_f64(value)
+    }
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let mut chars = self.value.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) => visitor.visit_char(c),
+            _ => Err(AlpacaParseError::BadFormat(format!(
+                "expected single character: {}",
+                self.value
+            ))),
+        }
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_bytes(self.value.as_bytes())
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_byte_buf(self.value.into_bytes())
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_enum(serde::de::value::StringDeserializer::new(self.value))
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(self.value)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "Option types are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "unit type is not supported as ALPACA parameter".to_owned(),
+        ))
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "unit struct is not supported as ALPACA parameter".to_owned(),
+        ))
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "sequences are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "tuples are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "tuple structs are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "maps are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(AlpacaParseError::BadFormat(
+            "structs are not supported as ALPACA parameters".to_owned(),
+        ))
+    }
+}
 
 #[derive(Deserialize, derive_more::Debug)]
 #[debug("{_0:?}")]
@@ -27,40 +260,29 @@ impl<ParamStr: ?Sized + Hash + Eq + Debug> OpaqueParams<ParamStr>
 where
     str: AsRef<ParamStr>,
 {
-    pub(crate) fn maybe_extract<T: 'static + DeserializeOwned>(
+    pub(crate) fn maybe_extract<T: DeserializeOwned>(
         &mut self,
         name: &'static str,
     ) -> super::Result<Option<T>> {
-        let value_opt = self.0.swap_remove(name.as_ref());
-
-        // Specialization: indices should return InvalidValue for negatives.
-        if let Some(ref value) = value_opt
-            && (TypeId::of::<T>() == TypeId::of::<usize>())
-            && value.trim_start().starts_with('-')
-        {
-            return Err(crate::ASCOMError::invalid_value(format!(
-                "Parameter {name:?} must be non-negative, got: {value}"
-            ))
-            .into());
-        }
-
-        value_opt
-            .map(|mut value| {
-                // Specialization: optimized path to avoid cloning the string.
-                if TypeId::of::<T>() == TypeId::of::<String>() {
-                    return T::deserialize(value.into_deserializer());
-                }
-                // Specialization: booleans in ASCOM must be case-insensitive.
-                if TypeId::of::<T>() == TypeId::of::<bool>() {
-                    value.make_ascii_lowercase();
-                }
-                serde_plain::from_str(&value)
+        self.0
+            .swap_remove(name.as_ref())
+            .map(|value| {
+                T::deserialize(AlpacaDeserializer { value }).map_err(|err| match err {
+                    AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
+                        name,
+                        value,
+                        target_type,
+                    },
+                    AlpacaParseError::BadFormat(msg) => Error::BadParameter {
+                        name,
+                        err: serde_plain::Error::custom(msg),
+                    },
+                })
             })
             .transpose()
-            .map_err(|err| Error::BadParameter { name, err })
     }
 
-    pub(crate) fn extract<T: 'static + DeserializeOwned>(
+    pub(crate) fn extract<T: DeserializeOwned>(
         &mut self,
         name: &'static str,
     ) -> super::Result<T> {

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -15,8 +15,8 @@ use std::hash::Hash;
 enum AlpacaParseError {
     /// Invalid format (not a valid integer/bool/etc) -> `BadParameter` (HTTP 400)
     BadFormat(String),
-    /// Valid i32 but out of range for target type -> `INVALID_VALUE` (ASCOM error)
-    OutOfRange { value: i32, target_type: &'static str },
+    /// Valid integer but out of range for target type -> `INVALID_VALUE` (ASCOM error)
+    OutOfRange { value: i64, target_type: &'static str },
 }
 
 impl fmt::Display for AlpacaParseError {
@@ -40,22 +40,23 @@ impl serde::de::Error for AlpacaParseError {
 
 /// Custom serde Deserializer for ALPACA parameters.
 ///
-/// Per ASCOM spec, integers are transmitted as i32, so we parse as i32 first
-/// then convert to the target type. This allows distinguishing parse errors
-/// (`BadParameter`) from range errors (`INVALID_VALUE`).
+/// Integers are parsed as i64 first, then converted to the target type.
+/// This allows distinguishing parse errors (`BadParameter`) from range errors
+/// (`INVALID_VALUE`), and supports both i32 device parameters and uint32
+/// transaction/identity parameters (`ClientID`, `ClientTransactionID`).
 struct AlpacaDeserializer {
     value: String,
 }
 
 impl AlpacaDeserializer {
-    /// Parse an integer per ALPACA spec: parse as i32, then convert to target type.
-    fn parse_integer<T: TryFrom<i32>>(&self) -> Result<T, AlpacaParseError> {
-        let i32_value: i32 = self.value.trim().parse().map_err(|_parse_err| {
+    /// Parse an integer: parse as i64 first, then convert to the target type.
+    fn parse_integer<T: TryFrom<i64>>(&self) -> Result<T, AlpacaParseError> {
+        let i64_value: i64 = self.value.trim().parse().map_err(|_parse_err| {
             AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
         })?;
 
-        T::try_from(i32_value).map_err(|_range_err| AlpacaParseError::OutOfRange {
-            value: i32_value,
+        T::try_from(i64_value).map_err(|_range_err| AlpacaParseError::OutOfRange {
+            value: i64_value,
             target_type: std::any::type_name::<T>(),
         })
     }
@@ -325,5 +326,99 @@ impl<S: Send + Sync> FromRequest<S> for ActionParams {
             )),
             _ => Err((StatusCode::METHOD_NOT_ALLOWED, "Method not allowed").into_response()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse<T: DeserializeOwned>(value: &str) -> super::super::Result<T> {
+        let deser = AlpacaDeserializer {
+            value: value.to_owned(),
+        };
+        T::deserialize(deser).map_err(|err| match err {
+            AlpacaParseError::OutOfRange { value, target_type } => Error::ParameterOutOfRange {
+                name: "test",
+                value,
+                target_type,
+            },
+            AlpacaParseError::BadFormat(msg) => Error::BadParameter {
+                name: "test",
+                err: serde_plain::Error::custom(msg),
+            },
+        })
+    }
+
+    #[test]
+    fn u32_above_i32_max() {
+        let val: u32 = parse("3000000000").expect("should parse u32 above i32::MAX");
+        assert_eq!(val, 3_000_000_000_u32);
+    }
+
+    #[test]
+    fn u32_max_value() {
+        let val: u32 = parse("4294967295").expect("should parse u32::MAX");
+        assert_eq!(val, u32::MAX);
+    }
+
+    #[test]
+    fn i32_positive() {
+        let val: i32 = parse("42").expect("should parse positive i32");
+        assert_eq!(val, 42_i32);
+    }
+
+    #[test]
+    fn i32_negative() {
+        let val: i32 = parse("-1").expect("should parse negative i32");
+        assert_eq!(val, -1_i32);
+    }
+
+    #[test]
+    fn i32_max_boundary() {
+        let val: i32 = parse("2147483647").expect("should parse i32::MAX");
+        assert_eq!(val, i32::MAX);
+    }
+
+    #[test]
+    fn i32_out_of_range() {
+        let err = parse::<i32>("3000000000").expect_err("should fail for i32 out of range");
+        assert!(
+            matches!(err, Error::ParameterOutOfRange { .. }),
+            "expected OutOfRange, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn u32_negative_out_of_range() {
+        let err = parse::<u32>("-1").expect_err("should fail for negative u32");
+        assert!(
+            matches!(err, Error::ParameterOutOfRange { .. }),
+            "expected OutOfRange, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn u8_out_of_range() {
+        let err = parse::<u8>("256").expect_err("should fail for u8 out of range");
+        assert!(
+            matches!(err, Error::ParameterOutOfRange { .. }),
+            "expected OutOfRange, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn bad_format_non_numeric() {
+        let err = parse::<u32>("abc").expect_err("should fail for non-numeric input");
+        assert!(
+            matches!(err, Error::BadParameter { .. }),
+            "expected BadParameter, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn whitespace_trimming() {
+        let val: u32 = parse("  42  ").expect("should parse with surrounding whitespace");
+        assert_eq!(val, 42_u32);
     }
 }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -467,4 +467,41 @@ mod tests {
         let val: ReprEnum = parse("1").expect("should parse valid variant");
         assert!(matches!(val, ReprEnum::One));
     }
+
+    // Forward-looking guard only: ASCOM Alpaca has no string-valued enum
+    // parameters today — every enum param (PierSide, DriveRate, TelescopeAxis,
+    // GuideDirection) is an integer-coded `serde_repr` enum that takes the integer
+    // path above, so `deserialize_enum` is currently unreached. These tests fix the
+    // behaviour should a plain `#[derive(Deserialize)]` string enum ever be added
+    // as a parameter: it must resolve a known variant by name and reject an unknown
+    // one as `InvalidValue`. They also pin why the body uses
+    // `visit_enum(StringDeserializer)` rather than a bare `visit_string` (which
+    // fails even on a valid name, since a derived enum's visitor implements only
+    // `visit_enum`). Safe to drop if we'd rather not cover an unreachable path.
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    enum StringEnum {
+        Alpha,
+        Beta,
+    }
+
+    #[test]
+    fn string_enum_known_variant() {
+        let val: StringEnum = parse("Beta").expect("should resolve a variant by name");
+        assert_eq!(val, StringEnum::Beta);
+    }
+
+    #[test]
+    fn string_enum_unknown_variant() {
+        let err = parse::<StringEnum>("Zeta").expect_err("unknown variant should fail");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::InvalidValue(_),
+                    ..
+                }
+            ),
+            "expected InvalidValue, got: {err:?}"
+        );
+    }
 }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -130,14 +130,9 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let mut chars = self.value.chars();
-        match (chars.next(), chars.next()) {
-            (Some(c), None) => visitor.visit_char(c),
-            _ => Err(AlpacaParseError::BadFormat(format!(
-                "expected single character: {}",
-                self.value
-            ))),
-        }
+        // serde's char visitor already validates that the string is exactly one
+        // character (rejecting empty/multi-char), so defer to it.
+        self.deserialize_str(visitor)
     }
 
     fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -47,10 +47,6 @@ struct AlpacaDeserializer {
 }
 
 impl AlpacaDeserializer {
-    /// Parse the value as `i64`. Every integer `deserialize_*` method forwards
-    /// here and hands the result to `visit_i64`; serde's built-in integer
-    /// `Deserialize` impls then narrow to the target type in a checked way,
-    /// mapping out-of-range values to `INVALID_VALUE` via `Error::custom`.
     fn parse_i64(&self) -> Result<i64, AlpacaParseError> {
         self.value.parse().map_err(|_parse_err| {
             AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
@@ -80,9 +76,6 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         }
     }
 
-    // All integer widths funnel through `deserialize_i64`: parse once as i64
-    // and let serde's target-type visitor narrow it in a checked way (an
-    // out-of-range value becomes `INVALID_VALUE`, never a silent truncation).
     fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         self.deserialize_i64(visitor)
     }
@@ -130,8 +123,6 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        // serde's char visitor already validates that the string is exactly one
-        // character (rejecting empty/multi-char), so defer to it.
         self.deserialize_str(visitor)
     }
 
@@ -165,7 +156,10 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        visitor.visit_enum(serde::de::value::StringDeserializer::new(self.value))
+        let index = u32::try_from(self.parse_i64()?).map_err(|_overflow| {
+            AlpacaParseError::InvalidValue(format!("no enum variant with index {}", self.value))
+        })?;
+        visitor.visit_enum(serde::de::value::U32Deserializer::new(index))
     }
 
     fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
@@ -272,10 +266,7 @@ where
             .transpose()
     }
 
-    pub(crate) fn extract<T: DeserializeOwned>(
-        &mut self,
-        name: &'static str,
-    ) -> super::Result<T> {
+    pub(crate) fn extract<T: DeserializeOwned>(&mut self, name: &'static str) -> super::Result<T> {
         self.maybe_extract(name)?
             .ok_or(Error::MissingParameter { name })
     }
@@ -449,7 +440,8 @@ mod tests {
 
     #[test]
     fn enum_repr_unknown_negative_variant() {
-        let err = parse::<ReprEnum>("-1").expect_err("should fail for negative out-of-variant value");
+        let err =
+            parse::<ReprEnum>("-1").expect_err("should fail for negative out-of-variant value");
         assert!(
             matches!(
                 err,
@@ -468,31 +460,59 @@ mod tests {
         assert!(matches!(val, ReprEnum::One));
     }
 
-    // Forward-looking guard only: ASCOM Alpaca has no string-valued enum
-    // parameters today — every enum param (PierSide, DriveRate, TelescopeAxis,
-    // GuideDirection) is an integer-coded `serde_repr` enum that takes the integer
-    // path above, so `deserialize_enum` is currently unreached. These tests fix the
-    // behaviour should a plain `#[derive(Deserialize)]` string enum ever be added
-    // as a parameter: it must resolve a known variant by name and reject an unknown
-    // one as `InvalidValue`. They also pin why the body uses
-    // `visit_enum(StringDeserializer)` rather than a bare `visit_string` (which
-    // fails even on a valid name, since a derived enum's visitor implements only
-    // `visit_enum`). Safe to drop if we'd rather not cover an unreachable path.
     #[derive(serde::Deserialize, Debug, PartialEq)]
-    enum StringEnum {
+    enum PlainEnum {
         Alpha,
         Beta,
     }
 
     #[test]
-    fn string_enum_known_variant() {
-        let val: StringEnum = parse("Beta").expect("should resolve a variant by name");
-        assert_eq!(val, StringEnum::Beta);
+    fn plain_enum_index_selects_variant() {
+        let val: PlainEnum = parse("1").expect("integer should select the variant by index");
+        assert_eq!(val, PlainEnum::Beta);
     }
 
     #[test]
-    fn string_enum_unknown_variant() {
-        let err = parse::<StringEnum>("Zeta").expect_err("unknown variant should fail");
+    fn plain_enum_index_zero() {
+        let val: PlainEnum = parse("0").expect("integer should select the variant by index");
+        assert_eq!(val, PlainEnum::Alpha);
+    }
+
+    #[test]
+    fn plain_enum_variant_name_rejected() {
+        // Enums decode as integers, so a string variant name is a format error
+        // (HTTP 400) — the same way a `serde_repr` enum rejects a non-integer.
+        let err = parse::<PlainEnum>("Beta").expect_err("variant name should not be accepted");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::BadFormat(_),
+                    ..
+                }
+            ),
+            "expected BadFormat, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn plain_enum_index_out_of_range() {
+        let err = parse::<PlainEnum>("5").expect_err("index past the last variant should fail");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::InvalidValue(_),
+                    ..
+                }
+            ),
+            "expected InvalidValue, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn plain_enum_negative_index() {
+        let err = parse::<PlainEnum>("-1").expect_err("negative index should fail");
         assert!(
             matches!(
                 err,

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -10,55 +10,50 @@ use serde::de::{DeserializeOwned, Deserializer, Visitor};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-/// Error type for Alpaca parameter parsing that distinguishes parse errors from range errors.
+/// Error type for Alpaca parameter parsing that distinguishes malformed input
+/// (HTTP 400) from values that parse but are semantically rejected (`INVALID_VALUE`).
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AlpacaParseError {
     /// Invalid format (not a valid integer/bool/etc) -> HTTP 400
     #[error("{0}")]
     BadFormat(String),
-    /// Valid integer but out of range for target type -> ASCOM `INVALID_VALUE`
-    #[error("value {value} is out of range for {target_type}")]
-    OutOfRange { value: i64, target_type: &'static str },
-    /// Primitive parsed successfully but the target type rejected the value
-    /// (e.g. an integer that doesn't match any variant of a `serde_repr`
-    /// enum) -> ASCOM `INVALID_VALUE`.
+    /// Primitive parsed successfully but the target type rejected the value:
+    /// an integer outside the target's range, or one that doesn't match any
+    /// variant of a `serde_repr` enum -> ASCOM `INVALID_VALUE`.
     #[error("{0}")]
     InvalidValue(String),
 }
 
 impl serde::de::Error for AlpacaParseError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        // Reached only from external code: `serde_repr` rejecting an integer
-        // that matches no variant, user `Deserialize` impls calling
-        // `Error::custom`, or the default `invalid_value`/`invalid_type`
-        // trait fallbacks. In every case the wire bytes parsed fine but the
-        // value was semantically rejected — that's ASCOM `INVALID_VALUE`.
-        // Our own `deserialize_*` paths never reach this: format errors are
-        // produced as `BadFormat` directly, and range errors as `OutOfRange`.
+        // Reached when serde semantically rejects a value whose wire bytes
+        // parsed fine: an integer outside the target type's range (serde's
+        // checked `visit_i64` narrowing), a `serde_repr` enum discriminant
+        // matching no variant, or a user `Deserialize` impl calling
+        // `Error::custom`. All of these are ASCOM `INVALID_VALUE`. Our own
+        // format errors are produced as `BadFormat` directly and never reach here.
         Self::InvalidValue(msg.to_string())
     }
 }
 
 /// Custom serde Deserializer for Alpaca parameters.
 ///
-/// Integers are parsed as i64 first, then converted to the target type.
-/// This allows distinguishing parse errors (`BadParameter`) from range errors
-/// (`INVALID_VALUE`), and supports both i32 device parameters and uint32
-/// transaction/identity parameters (`ClientID`, `ClientTransactionID`).
+/// Integers are parsed once as `i64` and handed to the target type's visitor,
+/// which narrows them in a checked way (out-of-range -> `INVALID_VALUE`). This
+/// covers both i32 device parameters and uint32 transaction/identity parameters
+/// (`ClientID`, `ClientTransactionID`) without per-type dispatch.
 struct AlpacaDeserializer {
     value: String,
 }
 
 impl AlpacaDeserializer {
-    /// Parse an integer: parse as i64 first, then convert to the target type.
-    fn parse_integer<T: TryFrom<i64>>(&self) -> Result<T, AlpacaParseError> {
-        let i64_value: i64 = self.value.trim().parse().map_err(|_parse_err| {
+    /// Parse the value as `i64`. Every integer `deserialize_*` method forwards
+    /// here and hands the result to `visit_i64`; serde's built-in integer
+    /// `Deserialize` impls then narrow to the target type in a checked way,
+    /// mapping out-of-range values to `INVALID_VALUE` via `Error::custom`.
+    fn parse_i64(&self) -> Result<i64, AlpacaParseError> {
+        self.value.parse().map_err(|_parse_err| {
             AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
-        })?;
-
-        T::try_from(i64_value).map_err(|_range_err| AlpacaParseError::OutOfRange {
-            value: i64_value,
-            target_type: std::any::type_name::<T>(),
         })
     }
 }
@@ -71,57 +66,64 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        match self.value.trim().to_ascii_lowercase().as_str() {
-            "true" => visitor.visit_bool(true),
-            "false" => visitor.visit_bool(false),
-            _ => Err(AlpacaParseError::BadFormat(format!(
+        // Alpaca booleans may use any casing; compare in place rather than
+        // allocating a lowercased copy of the value we already own.
+        if self.value.eq_ignore_ascii_case("true") {
+            visitor.visit_bool(true)
+        } else if self.value.eq_ignore_ascii_case("false") {
+            visitor.visit_bool(false)
+        } else {
+            Err(AlpacaParseError::BadFormat(format!(
                 "invalid boolean: {}",
                 self.value
-            ))),
+            )))
         }
     }
 
+    // All integer widths funnel through `deserialize_i64`: parse once as i64
+    // and let serde's target-type visitor narrow it in a checked way (an
+    // out-of-range value becomes `INVALID_VALUE`, never a silent truncation).
     fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_i8(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_i16(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_i32(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_i64(self.parse_integer()?)
+        visitor.visit_i64(self.parse_i64()?)
     }
 
     fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_u8(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_u16(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_u32(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_u64(self.parse_integer()?)
+        self.deserialize_i64(visitor)
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let value: f32 = self.value.trim().parse().map_err(|_parse_err| {
+        let value: f32 = self.value.parse().map_err(|_parse_err| {
             AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
         })?;
         visitor.visit_f32(value)
     }
 
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let value: f64 = self.value.trim().parse().map_err(|_parse_err| {
+        let value: f64 = self.value.parse().map_err(|_parse_err| {
             AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
         })?;
         visitor.visit_f64(value)
@@ -369,11 +371,11 @@ mod tests {
             matches!(
                 err,
                 Error::BadParameter {
-                    err: AlpacaParseError::OutOfRange { .. },
+                    err: AlpacaParseError::InvalidValue(_),
                     ..
                 }
             ),
-            "expected OutOfRange, got: {err:?}"
+            "expected InvalidValue, got: {err:?}"
         );
     }
 
@@ -384,11 +386,11 @@ mod tests {
             matches!(
                 err,
                 Error::BadParameter {
-                    err: AlpacaParseError::OutOfRange { .. },
+                    err: AlpacaParseError::InvalidValue(_),
                     ..
                 }
             ),
-            "expected OutOfRange, got: {err:?}"
+            "expected InvalidValue, got: {err:?}"
         );
     }
 
@@ -399,11 +401,11 @@ mod tests {
             matches!(
                 err,
                 Error::BadParameter {
-                    err: AlpacaParseError::OutOfRange { .. },
+                    err: AlpacaParseError::InvalidValue(_),
                     ..
                 }
             ),
-            "expected OutOfRange, got: {err:?}"
+            "expected InvalidValue, got: {err:?}"
         );
     }
 
@@ -420,12 +422,6 @@ mod tests {
             ),
             "expected BadFormat, got: {err:?}"
         );
-    }
-
-    #[test]
-    fn whitespace_trimming() {
-        let val: u32 = parse("  42  ").expect("should parse with surrounding whitespace");
-        assert_eq!(val, 42_u32);
     }
 
     // serde_repr emits `Error::custom("invalid value: N, expected one of: ...")`

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -19,11 +19,23 @@ pub(crate) enum AlpacaParseError {
     /// Valid integer but out of range for target type -> ASCOM `INVALID_VALUE`
     #[error("value {value} is out of range for {target_type}")]
     OutOfRange { value: i64, target_type: &'static str },
+    /// Primitive parsed successfully but the target type rejected the value
+    /// (e.g. an integer that doesn't match any variant of a `serde_repr`
+    /// enum) -> ASCOM `INVALID_VALUE`.
+    #[error("{0}")]
+    InvalidValue(String),
 }
 
 impl serde::de::Error for AlpacaParseError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::BadFormat(msg.to_string())
+        // Reached only from external code: `serde_repr` rejecting an integer
+        // that matches no variant, user `Deserialize` impls calling
+        // `Error::custom`, or the default `invalid_value`/`invalid_type`
+        // trait fallbacks. In every case the wire bytes parsed fine but the
+        // value was semantically rejected — that's ASCOM `INVALID_VALUE`.
+        // Our own `deserialize_*` paths never reach this: format errors are
+        // produced as `BadFormat` directly, and range errors as `OutOfRange`.
+        Self::InvalidValue(msg.to_string())
     }
 }
 
@@ -414,5 +426,54 @@ mod tests {
     fn whitespace_trimming() {
         let val: u32 = parse("  42  ").expect("should parse with surrounding whitespace");
         assert_eq!(val, 42_u32);
+    }
+
+    // serde_repr emits `Error::custom("invalid value: N, expected one of: ...")`
+    // when an integer doesn't match any variant. Without the visitor-error
+    // promotion, that would surface as `BadFormat` -> HTTP 400; ConformU's
+    // `TrackingRate Write` test (which sends `5` and `-1` for DriveRate) flagged
+    // exactly this path. It must produce `InvalidValue` -> ASCOM `INVALID_VALUE`.
+    #[derive(serde_repr::Deserialize_repr, Debug)]
+    #[repr(i32)]
+    enum ReprEnum {
+        Zero = 0,
+        One = 1,
+        Two = 2,
+    }
+
+    #[test]
+    fn enum_repr_unknown_positive_variant() {
+        let err = parse::<ReprEnum>("5").expect_err("should fail for out-of-variant value");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::InvalidValue(_),
+                    ..
+                }
+            ),
+            "expected InvalidValue, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn enum_repr_unknown_negative_variant() {
+        let err = parse::<ReprEnum>("-1").expect_err("should fail for negative out-of-variant value");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::InvalidValue(_),
+                    ..
+                }
+            ),
+            "expected InvalidValue, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn enum_repr_known_variant_round_trips() {
+        let val: ReprEnum = parse("1").expect("should parse valid variant");
+        assert!(matches!(val, ReprEnum::One));
     }
 }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -49,8 +49,6 @@ struct AlpacaDeserializer {
     value: String,
 }
 
-const ALPACA_PARAM: &dyn Expected = &"an ASCOM Alpaca-compliant parameter";
-
 impl<'de> Deserializer<'de> for AlpacaDeserializer {
     type Error = AlpacaParseError;
 
@@ -66,10 +64,7 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         } else if self.value.eq_ignore_ascii_case("false") {
             visitor.visit_bool(false)
         } else {
-            Err(serde::de::Error::invalid_type(
-                Unexpected::Str(&self.value),
-                &"a boolean",
-            ))
+            visitor.visit_string(self.value)
         }
     }
 
@@ -86,10 +81,10 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let value: i64 = self.value.parse().map_err(|_parse_err| {
-            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"an integer")
-        })?;
-        visitor.visit_i64(value)
+        match self.value.parse::<i64>() {
+            Ok(value) => visitor.visit_i64(value),
+            Err(_) => visitor.visit_string(self.value),
+        }
     }
 
     fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
@@ -109,37 +104,17 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let value: f32 = self.value.parse().map_err(|_parse_err| {
-            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"a float")
-        })?;
-        visitor.visit_f32(value)
+        match self.value.parse::<f32>() {
+            Ok(value) => visitor.visit_f32(value),
+            Err(_) => visitor.visit_string(self.value),
+        }
     }
 
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let value: f64 = self.value.parse().map_err(|_parse_err| {
-            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"a float")
-        })?;
-        visitor.visit_f64(value)
-    }
-
-    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_str(visitor)
-    }
-
-    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_bytes(self.value.as_bytes())
-    }
-
-    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_byte_buf(self.value.into_bytes())
-    }
-
-    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_string(self.value)
-    }
-
-    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_string(self.value)
+        match self.value.parse::<f64>() {
+            Ok(value) => visitor.visit_f64(value),
+            Err(_) => visitor.visit_string(self.value),
+        }
     }
 
     fn deserialize_newtype_struct<V: Visitor<'de>>(
@@ -156,8 +131,9 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        // Parse via i64 so a negative discriminant like -1 is rejected as
-        // INVALID_VALUE (see `plain_enum_negative_index`).
+        // Alpaca enums are integers. Parse as i64 so a negative value is rejected
+        // as INVALID_VALUE, not a malformed 400; non-negative indices defer to the
+        // derive's visitor, which emits invalid_value for out-of-range variants.
         let discriminant: i64 = self.value.parse().map_err(|_parse_err| {
             serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"an integer")
         })?;
@@ -170,86 +146,12 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         visitor.visit_enum(serde::de::value::U32Deserializer::new(index))
     }
 
-    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_string(self.value)
-    }
-
-    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_string(self.value)
-    }
-
-    fn deserialize_option<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Option,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_unit<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Unit,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_unit_struct<V: Visitor<'de>>(
-        self,
-        _name: &'static str,
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Unit,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Seq,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_tuple<V: Visitor<'de>>(
-        self,
-        _len: usize,
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Seq,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_tuple_struct<V: Visitor<'de>>(
-        self,
-        _name: &'static str,
-        _len: usize,
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Seq,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Map,
-            ALPACA_PARAM,
-        ))
-    }
-
-    fn deserialize_struct<V: Visitor<'de>>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        Err(serde::de::Error::invalid_type(
-            Unexpected::Map,
-            ALPACA_PARAM,
-        ))
+    // Every remaining shape has no scalar Alpaca wire representation. Forward
+    // them to `deserialize_any`, which offers the raw string to the target
+    // visitor; that visitor rejects it as `invalid_type` (-> BadFormat -> 400).
+    serde::forward_to_deserialize_any! {
+        char str string bytes byte_buf identifier ignored_any
+        option unit unit_struct seq tuple tuple_struct map struct
     }
 }
 
@@ -428,18 +330,20 @@ mod tests {
 
     #[test]
     fn bad_format_non_boolean() {
-        // A string that isn't a boolean is the wrong *kind* of input -> HTTP 400,
-        // routed through serde's `invalid_type` like a non-numeric integer.
+        // A string that isn't a boolean is the wrong *kind* of input -> HTTP 400.
+        // Handing the raw value to the `bool` visitor yields serde's own
+        // `invalid_type` error, identical to a hand-built one.
         let err = parse::<bool>("maybe").expect_err("should fail for non-boolean input");
-        assert!(
-            matches!(
-                err,
-                Error::BadParameter {
-                    err: AlpacaParseError::BadFormat(_),
-                    ..
-                }
-            ),
-            "expected BadFormat, got: {err:?}"
+        let Error::BadParameter {
+            err: AlpacaParseError::BadFormat(msg),
+            ..
+        } = &err
+        else {
+            panic!("expected BadFormat, got: {err:?}");
+        };
+        assert_eq!(
+            msg.as_str(),
+            "invalid type: string \"maybe\", expected a boolean"
         );
     }
 
@@ -478,7 +382,7 @@ mod tests {
         };
         assert_eq!(
             msg.as_str(),
-            "invalid type: sequence, expected an ASCOM Alpaca-compliant parameter"
+            "invalid type: string \"5\", expected a sequence"
         );
     }
 
@@ -553,49 +457,50 @@ mod tests {
     }
 
     #[test]
-    fn plain_enum_variant_name_rejected() {
-        // Enums decode as integers, so a string variant name is a format error
-        // (HTTP 400) — the same way a `serde_repr` enum rejects a non-integer.
-        let err = parse::<PlainEnum>("Beta").expect_err("variant name should not be accepted");
+    fn plain_enum_out_of_range_maps_to_invalid_value_via_both_arms() {
+        // Both out-of-range indices become INVALID_VALUE (1025), but through two
+        // different arms — which is exactly why `deserialize_enum` parses i64
+        // first. A non-negative index is handed to `U32Deserializer`, so the
+        // derive's own `visit_u64` rejects it; a negative value can't be a u32, so
+        // our `try_from` arm rejects it before it could ever reach the derive.
+        let positive = parse::<PlainEnum>("5").expect_err("index past the last variant");
+        let Error::BadParameter {
+            err: AlpacaParseError::InvalidValue(msg),
+            ..
+        } = &positive
+        else {
+            panic!("expected InvalidValue for 5, got: {positive:?}");
+        };
+        assert!(
+            msg.contains("variant index"),
+            "5 should be rejected by the derive's visit_u64 arm, got: {msg}"
+        );
+
+        let negative = parse::<PlainEnum>("-1").expect_err("negative index");
+        let Error::BadParameter {
+            err: AlpacaParseError::InvalidValue(msg),
+            ..
+        } = &negative
+        else {
+            panic!("expected InvalidValue for -1, got: {negative:?}");
+        };
+        assert!(
+            msg.contains("a valid enum value (u32)"),
+            "-1 should be rejected by our try_from arm, got: {msg}"
+        );
+
+        // A non-integer is a different class entirely: BadFormat -> 400. A direct
+        // u32 parse would wrongly collapse `-1` into this same bucket.
+        let non_integer = parse::<PlainEnum>("Beta").expect_err("variant name is not an integer");
         assert!(
             matches!(
-                err,
+                non_integer,
                 Error::BadParameter {
                     err: AlpacaParseError::BadFormat(_),
                     ..
                 }
             ),
-            "expected BadFormat, got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn plain_enum_index_out_of_range() {
-        let err = parse::<PlainEnum>("5").expect_err("index past the last variant should fail");
-        assert!(
-            matches!(
-                err,
-                Error::BadParameter {
-                    err: AlpacaParseError::InvalidValue(_),
-                    ..
-                }
-            ),
-            "expected InvalidValue, got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn plain_enum_negative_index() {
-        let err = parse::<PlainEnum>("-1").expect_err("negative index should fail");
-        assert!(
-            matches!(
-                err,
-                Error::BadParameter {
-                    err: AlpacaParseError::InvalidValue(_),
-                    ..
-                }
-            ),
-            "expected InvalidValue, got: {err:?}"
+            "expected BadFormat for Beta, got: {non_integer:?}"
         );
     }
 }

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -6,7 +6,7 @@ use axum::response::{IntoResponse, Response};
 use http::{Method, StatusCode};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde::de::{DeserializeOwned, Deserializer, Visitor};
+use serde::de::{DeserializeOwned, Deserializer, Expected, Unexpected, Visitor};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
@@ -17,42 +17,39 @@ pub(crate) enum AlpacaParseError {
     /// Invalid format (not a valid integer/bool/etc) -> HTTP 400
     #[error("{0}")]
     BadFormat(String),
-    /// Primitive parsed successfully but the target type rejected the value:
-    /// an integer outside the target's range, or one that doesn't match any
-    /// variant of a `serde_repr` enum -> ASCOM `INVALID_VALUE`.
+    /// A value that parsed but the target rejected: an out-of-range integer or
+    /// an unknown `serde_repr` variant -> ASCOM `INVALID_VALUE`.
     #[error("{0}")]
     InvalidValue(String),
 }
 
 impl serde::de::Error for AlpacaParseError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        // Reached when serde semantically rejects a value whose wire bytes
-        // parsed fine: an integer outside the target type's range (serde's
-        // checked `visit_i64` narrowing), a `serde_repr` enum discriminant
-        // matching no variant, or a user `Deserialize` impl calling
-        // `Error::custom`. All of these are ASCOM `INVALID_VALUE`. Our own
-        // format errors are produced as `BadFormat` directly and never reach here.
+        // serde calls this when a value parsed but the target rejected it: an
+        // out-of-range integer, an unknown `serde_repr` variant, or a
+        // `Deserialize` impl calling `Error::custom`. All map to `INVALID_VALUE`.
         Self::InvalidValue(msg.to_string())
+    }
+
+    fn invalid_type(unexp: Unexpected<'_>, exp: &dyn Expected) -> Self {
+        // The value is the wrong *kind* for the target (non-boolean string for a
+        // `bool`, non-integer for an integer, an unsupported shape): a malformed
+        // request -> HTTP 400, unlike `invalid_value`/`custom` (-> `INVALID_VALUE`).
+        Self::BadFormat(format!("invalid type: {unexp}, expected {exp}"))
     }
 }
 
 /// Custom serde Deserializer for Alpaca parameters.
 ///
 /// Integers are parsed once as `i64` and handed to the target type's visitor,
-/// which narrows them in a checked way (out-of-range -> `INVALID_VALUE`). This
-/// covers both i32 device parameters and uint32 transaction/identity parameters
-/// (`ClientID`, `ClientTransactionID`) without per-type dispatch.
+/// which narrows them in a checked way. This covers both i32 device parameters
+/// and uint32 transaction/identity parameters (`ClientID`, `ClientTransactionID`)
+/// without per-type dispatch.
 struct AlpacaDeserializer {
     value: String,
 }
 
-impl AlpacaDeserializer {
-    fn parse_i64(&self) -> Result<i64, AlpacaParseError> {
-        self.value.parse().map_err(|_parse_err| {
-            AlpacaParseError::BadFormat(format!("invalid integer: {}", self.value))
-        })
-    }
-}
+const ALPACA_PARAM: &dyn Expected = &"an ASCOM Alpaca-compliant parameter";
 
 impl<'de> Deserializer<'de> for AlpacaDeserializer {
     type Error = AlpacaParseError;
@@ -69,10 +66,10 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         } else if self.value.eq_ignore_ascii_case("false") {
             visitor.visit_bool(false)
         } else {
-            Err(AlpacaParseError::BadFormat(format!(
-                "invalid boolean: {}",
-                self.value
-            )))
+            Err(serde::de::Error::invalid_type(
+                Unexpected::Str(&self.value),
+                &"a boolean",
+            ))
         }
     }
 
@@ -89,7 +86,10 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        visitor.visit_i64(self.parse_i64()?)
+        let value: i64 = self.value.parse().map_err(|_parse_err| {
+            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"an integer")
+        })?;
+        visitor.visit_i64(value)
     }
 
     fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
@@ -110,14 +110,14 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         let value: f32 = self.value.parse().map_err(|_parse_err| {
-            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"a float")
         })?;
         visitor.visit_f32(value)
     }
 
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         let value: f64 = self.value.parse().map_err(|_parse_err| {
-            AlpacaParseError::BadFormat(format!("invalid float: {}", self.value))
+            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"a float")
         })?;
         visitor.visit_f64(value)
     }
@@ -156,8 +156,16 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        let index = u32::try_from(self.parse_i64()?).map_err(|_overflow| {
-            AlpacaParseError::InvalidValue(format!("no enum variant with index {}", self.value))
+        // Parse via i64 so a negative discriminant like -1 is rejected as
+        // INVALID_VALUE (see `plain_enum_negative_index`).
+        let discriminant: i64 = self.value.parse().map_err(|_parse_err| {
+            serde::de::Error::invalid_type(Unexpected::Str(&self.value), &"an integer")
+        })?;
+        let index = u32::try_from(discriminant).map_err(|_overflow| {
+            serde::de::Error::invalid_value(
+                Unexpected::Signed(discriminant),
+                &"a valid enum value (u32)",
+            )
         })?;
         visitor.visit_enum(serde::de::value::U32Deserializer::new(index))
     }
@@ -171,14 +179,16 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
     }
 
     fn deserialize_option<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "Option types are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Option,
+            ALPACA_PARAM,
         ))
     }
 
     fn deserialize_unit<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "unit type is not supported as Alpaca parameter".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Unit,
+            ALPACA_PARAM,
         ))
     }
 
@@ -187,14 +197,16 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _name: &'static str,
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "unit struct is not supported as Alpaca parameter".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Unit,
+            ALPACA_PARAM,
         ))
     }
 
     fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "sequences are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Seq,
+            ALPACA_PARAM,
         ))
     }
 
@@ -203,8 +215,9 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _len: usize,
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "tuples are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Seq,
+            ALPACA_PARAM,
         ))
     }
 
@@ -214,14 +227,16 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _len: usize,
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "tuple structs are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Seq,
+            ALPACA_PARAM,
         ))
     }
 
     fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "maps are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Map,
+            ALPACA_PARAM,
         ))
     }
 
@@ -231,8 +246,9 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         _fields: &'static [&'static str],
         _visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        Err(AlpacaParseError::BadFormat(
-            "structs are not supported as Alpaca parameters".to_owned(),
+        Err(serde::de::Error::invalid_type(
+            Unexpected::Map,
+            ALPACA_PARAM,
         ))
     }
 }
@@ -410,6 +426,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn bad_format_non_boolean() {
+        // A string that isn't a boolean is the wrong *kind* of input -> HTTP 400,
+        // routed through serde's `invalid_type` like a non-numeric integer.
+        let err = parse::<bool>("maybe").expect_err("should fail for non-boolean input");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::BadFormat(_),
+                    ..
+                }
+            ),
+            "expected BadFormat, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn bool_is_case_insensitive() {
+        assert!(parse::<bool>("True").expect("mixed-case true"));
+        assert!(!parse::<bool>("FALSE").expect("upper-case false"));
+    }
+
+    #[test]
+    fn bad_format_non_float() {
+        let err = parse::<f64>("abc").expect_err("should fail for non-float input");
+        assert!(
+            matches!(
+                err,
+                Error::BadParameter {
+                    err: AlpacaParseError::BadFormat(_),
+                    ..
+                }
+            ),
+            "expected BadFormat, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_composite_type_is_bad_format() {
+        // Composite Rust types have no scalar Alpaca wire representation, so a
+        // parameter typed as one is rejected as malformed -> HTTP 400.
+        let err = parse::<Vec<u32>>("5").expect_err("sequences aren't valid Alpaca parameters");
+        let Error::BadParameter {
+            err: AlpacaParseError::BadFormat(msg),
+            ..
+        } = &err
+        else {
+            panic!("expected BadFormat, got: {err:?}");
+        };
+        assert_eq!(
+            msg.as_str(),
+            "invalid type: sequence, expected an ASCOM Alpaca-compliant parameter"
+        );
+    }
+
     // serde_repr emits `Error::custom("invalid value: N, expected one of: ...")`
     // when an integer doesn't match any variant. Without the visitor-error
     // promotion, that would surface as `BadFormat` -> HTTP 400; ConformU's
@@ -417,15 +489,17 @@ mod tests {
     // exactly this path. It must produce `InvalidValue` -> ASCOM `INVALID_VALUE`.
     #[derive(serde_repr::Deserialize_repr, Debug)]
     #[repr(i32)]
-    enum ReprEnum {
-        Zero = 0,
-        One = 1,
-        Two = 2,
+    enum DriveRateTestEnum {
+        Sidereal = 0,
+        Lunar = 1,
+        Solar = 2,
+        King = 3,
     }
 
     #[test]
     fn enum_repr_unknown_positive_variant() {
-        let err = parse::<ReprEnum>("5").expect_err("should fail for out-of-variant value");
+        let err =
+            parse::<DriveRateTestEnum>("5").expect_err("should fail for out-of-variant value");
         assert!(
             matches!(
                 err,
@@ -440,8 +514,8 @@ mod tests {
 
     #[test]
     fn enum_repr_unknown_negative_variant() {
-        let err =
-            parse::<ReprEnum>("-1").expect_err("should fail for negative out-of-variant value");
+        let err = parse::<DriveRateTestEnum>("-1")
+            .expect_err("should fail for negative out-of-variant value");
         assert!(
             matches!(
                 err,
@@ -456,8 +530,8 @@ mod tests {
 
     #[test]
     fn enum_repr_known_variant_round_trips() {
-        let val: ReprEnum = parse("1").expect("should parse valid variant");
-        assert!(matches!(val, ReprEnum::One));
+        let val: DriveRateTestEnum = parse("1").expect("should parse valid variant");
+        assert!(matches!(val, DriveRateTestEnum::Lunar));
     }
 
     #[derive(serde::Deserialize, Debug, PartialEq)]

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -49,6 +49,19 @@ struct AlpacaDeserializer {
     value: String,
 }
 
+// The fixed-width integer methods are all required but identical — parse once as
+// `i64` and let the target visitor narrow it — so forward them to `deserialize_i64`
+// via a macro to save the boilerplate of seven near-identical copies.
+macro_rules! forward_int_to_i64 {
+    ($($method:ident)*) => {
+        $(
+            fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+                self.deserialize_i64(visitor)
+            }
+        )*
+    };
+}
+
 impl<'de> Deserializer<'de> for AlpacaDeserializer {
     type Error = AlpacaParseError;
 
@@ -68,18 +81,6 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         }
     }
 
-    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         match self.value.parse::<i64>() {
             Ok(value) => visitor.visit_i64(value),
@@ -87,20 +88,9 @@ impl<'de> Deserializer<'de> for AlpacaDeserializer {
         }
     }
 
-    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        self.deserialize_i64(visitor)
+    forward_int_to_i64! {
+        deserialize_i8 deserialize_i16 deserialize_i32
+        deserialize_u8 deserialize_u16 deserialize_u32 deserialize_u64
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -52,6 +52,13 @@ where
         match self.response {
             Ok(response) => Ok(Ok(response)),
             Err(Error::Ascom(err)) => Ok(Err(err)),
+            Err(Error::ParameterOutOfRange {
+                name,
+                value,
+                target_type,
+            }) => Ok(Err(ASCOMError::invalid_value(format!(
+                "Parameter {name:?} value {value} is out of range for {target_type}"
+            )))),
             Err(err @ (Error::MissingParameter { .. } | Error::BadParameter { .. })) => {
                 Err((StatusCode::BAD_REQUEST, err.to_string()))
             }

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -1,3 +1,4 @@
+use super::params::AlpacaParseError;
 use super::{Error, ResponseWithTransaction};
 use crate::response::ValueResponse;
 use crate::{ASCOMError, ASCOMErrorCode, ASCOMResult};
@@ -52,10 +53,9 @@ where
         match self.response {
             Ok(response) => Ok(Ok(response)),
             Err(Error::Ascom(err)) => Ok(Err(err)),
-            Err(Error::ParameterOutOfRange {
+            Err(Error::BadParameter {
                 name,
-                value,
-                target_type,
+                err: AlpacaParseError::OutOfRange { value, target_type },
             }) => Ok(Err(ASCOMError::invalid_value(format!(
                 "Parameter {name:?} value {value} is out of range for {target_type}"
             )))),

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -55,12 +55,6 @@ where
             Err(Error::Ascom(err)) => Ok(Err(err)),
             Err(Error::BadParameter {
                 name,
-                err: AlpacaParseError::OutOfRange { value, target_type },
-            }) => Ok(Err(ASCOMError::invalid_value(format!(
-                "Parameter {name:?} value {value} is out of range for {target_type}"
-            )))),
-            Err(Error::BadParameter {
-                name,
                 err: AlpacaParseError::InvalidValue(msg),
             }) => Ok(Err(ASCOMError::invalid_value(format!(
                 "Parameter {name:?}: {msg}"

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -59,6 +59,12 @@ where
             }) => Ok(Err(ASCOMError::invalid_value(format!(
                 "Parameter {name:?} value {value} is out of range for {target_type}"
             )))),
+            Err(Error::BadParameter {
+                name,
+                err: AlpacaParseError::InvalidValue(msg),
+            }) => Ok(Err(ASCOMError::invalid_value(format!(
+                "Parameter {name:?}: {msg}"
+            )))),
             Err(err @ (Error::MissingParameter { .. } | Error::BadParameter { .. })) => {
                 Err((StatusCode::BAD_REQUEST, err.to_string()))
             }


### PR DESCRIPTION
## Summary

Replace `serde_plain::from_str` with a custom `serde::Deserializer` for Alpaca request parameters, so a value that parses but the target rejects (an out-of-range integer, an unknown enum discriminant) returns ASCOM `INVALID_VALUE` (error 1025, HTTP 200) instead of HTTP 400. Genuinely malformed input (e.g. `Id=abc`) still returns HTTP 400.

Closes RReverser/ascom-alpaca-rs#5

## Motivation

The ASCOM Alpaca spec and ConformU require `INVALID_VALUE` for parseable-but-out-of-range values — e.g. `Id=999` to a 4-port `Switch` should return HTTP 200 with `ErrorNumber: 1025`, not HTTP 400. Previously `OpaqueParams::maybe_extract` used `serde_plain::from_str`, which collapsed every failure (malformed input, negative-for-unsigned, out-of-range) into one `ParseIntError` → `BadParameter` → HTTP 400, so ConformU's out-of-range checks were reported as protocol errors.

## How it works

A custom `AlpacaDeserializer` parses each parameter and classifies failures through serde's own `de::Error` methods, mapped to two outcomes:

- **`invalid_type` → `AlpacaParseError::BadFormat` → HTTP 400** — the value is the wrong *kind*: a non-integer for an integer, a non-boolean for a `bool`, or a Rust shape Alpaca params can't represent (sequence/map/struct/option/…).
- **`custom` / `invalid_value` → `AlpacaParseError::InvalidValue` → ASCOM 1025 (HTTP 200)** — the value parsed but the target rejected it: an integer outside the target's range (serde's checked `visit_i64` narrowing) or an unknown `serde_repr` discriminant (e.g. ConformU's `TrackingRate=5`/`-1`, which `serde_repr` rejects via `Error::custom`).

Integers are parsed once as `i64` and handed to the target's visitor for checked narrowing — `i64` covers every Alpaca integer parameter (i8…i32, u8…u32 incl. `ClientID`/`ClientTransactionID`) without per-type dispatch. `Error::BadParameter` carries the `AlpacaParseError`; `ResponseWithTransaction<Result<T>>::into_response` maps `InvalidValue` to `ASCOMError::invalid_value` (HTTP 200 + 1025), while `BadFormat`/`MissingParameter` return HTTP 400.

## Changes

- `src/server/params.rs`: custom `AlpacaDeserializer` + `AlpacaParseError` (`BadFormat`/`InvalidValue`); `serde::de::Error` impl overrides `custom` (→`InvalidValue`) and `invalid_type` (→`BadFormat`); unsupported parameter shapes rejected via `invalid_type`. Unit tests for range-vs-format classification, u32 above `i32::MAX`, negative-for-unsigned, `serde_repr` + plain-enum rejection, malformed bool/float, and composite-shape rejection.
- `src/server/error.rs`: `Error::BadParameter` carries `AlpacaParseError` (was `serde_plain::Error`).
- `src/server/response.rs`: `BadParameter { err: InvalidValue(_) }` → `ASCOMError::invalid_value`; other parameter errors → HTTP 400.
- `Cargo.toml`: drop the `serde_plain` dependency.

## Test plan

- [x] CI clippy matrix (all 7 feature combos, `RUSTFLAGS=-D warnings`) clean
- [x] `cargo +nightly fmt --check` clean
- [x] `params.rs` unit tests pass (21)
- [x] ConformU: out-of-range `Switch.Id` → ASCOM 1025, not HTTP 400
- [x] ConformU: `TrackingRate Write` out-of-range values (`5`, `-1`) → 1025
- [x] Malformed input (e.g. `Id=abc`) → HTTP 400
