### PR TITLE
Replace netdev with if-addrs to fix macOS compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "android-properties",
  "bitflags 2.13.0",
  "cc",
- "jni 0.22.4",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -293,13 +293,13 @@ dependencies = [
  "fnv",
  "futures",
  "http",
+ "if-addrs",
  "impl_serialize",
  "indexmap",
  "macro_rules_attribute",
  "mediatype",
  "mime",
  "ndarray",
- "netdev",
  "num_enum",
  "paste",
  "rand",
@@ -840,12 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,8 +1328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
- "block2 0.6.2",
- "libc",
  "objc2 0.6.4",
 ]
 
@@ -1357,17 +1349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
-dependencies = [
- "libc",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -2377,6 +2358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,22 +2438,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if 1.0.4",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "jni"
@@ -2674,12 +2649,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "mac-addr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2924,65 +2893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
-]
-
-[[package]]
-name = "netdev"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
-dependencies = [
- "block2 0.6.2",
- "dispatch2",
- "dlopen2",
- "ipnet",
- "jni 0.21.1",
- "libc",
- "mac-addr",
- "ndk-context",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-sys",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-wlan",
- "objc2-foundation 0.3.2",
- "objc2-system-configuration",
- "once_cell",
- "plist",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "netlink-packet-core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
-dependencies = [
- "paste",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
-dependencies = [
- "bitflags 2.13.0",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
-dependencies = [
- "bytes",
- "libc",
- "log",
 ]
 
 [[package]]
@@ -3241,9 +3151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
- "block2 0.6.2",
  "dispatch2",
- "libc",
  "objc2 0.6.4",
 ]
 
@@ -3285,20 +3193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-wlan"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
-dependencies = [
- "bitflags 2.13.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-security",
- "objc2-security-foundation",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,7 +3219,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
- "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3404,26 +3297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "objc2 0.6.4",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-security-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
-dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,16 +3304,6 @@ checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
- "bitflags 2.13.0",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3735,19 +3598,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "plist"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
 
 [[package]]
 name = "plotters"
@@ -5392,7 +5242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
- "jni 0.22.4",
+ "jni",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -5731,15 +5581,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5772,21 +5613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5833,12 +5659,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5851,12 +5671,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5866,12 +5680,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5899,12 +5707,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5914,12 +5716,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5935,12 +5731,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5950,12 +5740,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ derive_more = { workspace = true, features = [
 	"into",
 ] }
 dtor = { version = "1.0.5", optional = true }
-netdev = { version = "0.45.0" }
+if-addrs = "0.15.0"
 eyre = { workspace = true }
 futures = { workspace = true }
 http = { version = "1.4.0", optional = true }

--- a/src/client/discovery.rs
+++ b/src/client/discovery.rs
@@ -45,7 +45,11 @@ impl BoundClient {
     async fn send_discovery_msg(&self, addr: Ipv6Addr, intf: &GroupedInterface) {
         let send_op = async {
             if addr.is_multicast() {
-                SockRef::from(&self.socket).set_multicast_if_v6(intf.index)?;
+                let Some(index) = intf.index else {
+                    tracing::warn!("skipping multicast send: no interface index");
+                    return Ok(());
+                };
+                SockRef::from(&self.socket).set_multicast_if_v6(index)?;
             }
             // UDP packets are sent as whole messages, no need to check length.
             self.socket

--- a/src/client/discovery.rs
+++ b/src/client/discovery.rs
@@ -45,8 +45,8 @@ impl BoundClient {
     async fn send_discovery_msg(&self, addr: Ipv6Addr, intf: &GroupedInterface) {
         let send_op = async {
             if addr.is_multicast() {
-                let Some(index) = intf.index else {
-                    tracing::warn!("skipping multicast send: no interface index");
+                let Some(index) = intf.ipv6_index else {
+                    tracing::warn!("skipping multicast send: no IPv6 interface index");
                     return Ok(());
                 };
                 SockRef::from(&self.socket).set_multicast_if_v6(index)?;

--- a/src/client/discovery.rs
+++ b/src/client/discovery.rs
@@ -1,10 +1,9 @@
 use crate::api::TypedDevice;
 use crate::discovery::{
-    AlpacaPort, DEFAULT_DISCOVERY_PORT, DISCOVERY_ADDR_V6, DISCOVERY_MSG, bind_socket,
-    get_active_interfaces,
+    AlpacaPort, DEFAULT_DISCOVERY_PORT, DISCOVERY_ADDR_V6, DISCOVERY_MSG, GroupedInterface,
+    bind_socket, get_active_interfaces,
 };
 use futures::StreamExt;
-use netdev::prelude::{Interface, InterfaceType};
 use socket2::SockRef;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
@@ -36,14 +35,14 @@ pub struct Client {
 pub struct BoundClient {
     client: Client,
     socket: UdpSocket,
-    interfaces: Vec<Interface>,
+    interfaces: Vec<GroupedInterface>,
     buf: Vec<u8>,
     seen: Vec<SocketAddr>,
 }
 
 impl BoundClient {
-    #[tracing::instrument(level = "trace", skip_all, fields(%addr, intf.friendly_name = intf.friendly_name.as_ref(), intf.description = intf.description.as_ref(), ?intf.ipv4, ?intf.ipv6))]
-    async fn send_discovery_msg(&self, addr: Ipv6Addr, intf: &Interface) {
+    #[tracing::instrument(level = "trace", skip_all, fields(%addr, intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
+    async fn send_discovery_msg(&self, addr: Ipv6Addr, intf: &GroupedInterface) {
         let send_op = async {
             if addr.is_multicast() {
                 SockRef::from(&self.socket).set_multicast_if_v6(intf.index)?;
@@ -63,8 +62,8 @@ impl BoundClient {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn send_discovery_msgs(&self) {
         for intf in &self.interfaces {
-            for net in &intf.ipv4 {
-                let broadcast = net.addr() | !net.netmask();
+            for v4 in &intf.ipv4 {
+                let broadcast = v4.addr | !v4.netmask;
 
                 self.send_discovery_msg(broadcast.to_ipv6_mapped(), intf)
                     .await;
@@ -72,7 +71,7 @@ impl BoundClient {
 
             if !intf.ipv6.is_empty() {
                 self.send_discovery_msg(
-                    if intf.if_type == InterfaceType::Loopback {
+                    if intf.is_loopback {
                         // Loopback interface doesn't have a link-local address
                         // so it can't be used for multicast.
                         Ipv6Addr::LOCALHOST
@@ -172,7 +171,7 @@ impl Client {
         // addresses (e.g. 127.255.255.255). Without this, send_to returns
         // EACCES and IPv4 discovery silently fails.
         socket.set_broadcast(true)?;
-        let interfaces = spawn_blocking(|| get_active_interfaces().collect()).await?;
+        let interfaces = spawn_blocking(get_active_interfaces).await??;
         Ok(BoundClient {
             client: self,
             socket,

--- a/src/client/discovery.rs
+++ b/src/client/discovery.rs
@@ -5,6 +5,7 @@ use crate::discovery::{
 };
 use futures::StreamExt;
 use socket2::SockRef;
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 use tokio::task::spawn_blocking;
@@ -35,14 +36,14 @@ pub struct Client {
 pub struct BoundClient {
     client: Client,
     socket: UdpSocket,
-    interfaces: Vec<GroupedInterface>,
+    interfaces: HashMap<String, GroupedInterface>,
     buf: Vec<u8>,
     seen: Vec<SocketAddr>,
 }
 
 impl BoundClient {
-    #[tracing::instrument(level = "trace", skip_all, fields(%addr, intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
-    async fn send_discovery_msg(&self, addr: Ipv6Addr, intf: &GroupedInterface) {
+    #[tracing::instrument(level = "trace", skip_all, fields(%addr, intf.name = %name, ?intf.ipv4, ?intf.ipv6))]
+    async fn send_discovery_msg(&self, addr: Ipv6Addr, name: &str, intf: &GroupedInterface) {
         let send_op = async {
             if addr.is_multicast() {
                 let Some(index) = intf.ipv6_index else {
@@ -65,11 +66,11 @@ impl BoundClient {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn send_discovery_msgs(&self) {
-        for intf in &self.interfaces {
+        for (name, intf) in &self.interfaces {
             for v4 in &intf.ipv4 {
                 let broadcast = v4.addr | !v4.netmask;
 
-                self.send_discovery_msg(broadcast.to_ipv6_mapped(), intf)
+                self.send_discovery_msg(broadcast.to_ipv6_mapped(), name, intf)
                     .await;
             }
 
@@ -82,6 +83,7 @@ impl BoundClient {
                     } else {
                         DISCOVERY_ADDR_V6
                     },
+                    name,
                     intf,
                 )
                 .await;

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -158,9 +158,13 @@ mod tests {
 
     /// Determine the default IPv4 address using the UDP socket trick:
     /// "connect" to a non-routable address and read back the source IP the OS chose.
+    ///
+    /// Uses a TEST-NET-1 address (RFC 5737). VPNs commonly push routes for
+    /// RFC1918 prefixes, which would make a `10.0.0.0/8` target resolve to
+    /// the VPN interface instead of the true default route.
     fn get_default_ipv4() -> Option<Ipv4Addr> {
         let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-        socket.connect("10.254.254.254:1").ok()?;
+        socket.connect("192.0.2.1:1").ok()?;
         match socket.local_addr().ok()?.ip() {
             IpAddr::V4(ip) => Some(ip),
             IpAddr::V6(_) => None,

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,6 +6,7 @@ pub use crate::client::{BoundDiscoveryClient, DiscoveryClient};
 pub use crate::server::{BoundDiscoveryServer, DiscoveryServer};
 use serde::{Deserialize, Serialize};
 use socket2::{Domain, Protocol, Socket, Type};
+use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 
@@ -36,39 +37,24 @@ pub(crate) struct Ipv4Info {
 /// (`IPV6_MULTICAST_IF`, `IPV6_JOIN_GROUP`) need the V6-specific one. We don't
 /// store a V4 index because IPv4 discovery uses subnet-directed broadcast,
 /// where the routing table picks the outbound interface by destination.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct GroupedInterface {
-    pub(crate) name: String,
     pub(crate) ipv6_index: Option<u32>,
     pub(crate) is_loopback: bool,
     pub(crate) ipv4: Vec<Ipv4Info>,
     pub(crate) ipv6: Vec<Ipv6Addr>,
 }
 
-pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
-    let mut interfaces: Vec<GroupedInterface> = Vec::new();
+pub(crate) fn get_active_interfaces() -> eyre::Result<HashMap<String, GroupedInterface>> {
+    let mut interfaces = HashMap::<String, GroupedInterface>::new();
 
     for iface in if_addrs::get_if_addrs()? {
         if !iface.is_oper_up() {
             continue;
         }
 
-        let grouped = if let Some(existing) = interfaces.iter_mut().find(|g| g.name == iface.name)
-        {
-            existing.is_loopback |= iface.is_loopback();
-            existing
-        } else {
-            interfaces.push(GroupedInterface {
-                name: iface.name.clone(),
-                ipv6_index: None,
-                is_loopback: iface.is_loopback(),
-                ipv4: Vec::new(),
-                ipv6: Vec::new(),
-            });
-            interfaces
-                .last_mut()
-                .expect("internal error: just pushed an element")
-        };
+        let grouped = interfaces.entry(iface.name.clone()).or_default();
+        grouped.is_loopback |= iface.is_loopback();
 
         match iface.addr {
             if_addrs::IfAddr::V4(v4) => {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -32,7 +32,7 @@ pub(crate) struct Ipv4Info {
 #[derive(Debug)]
 pub(crate) struct GroupedInterface {
     pub(crate) name: String,
-    pub(crate) index: u32,
+    pub(crate) index: Option<u32>,
     pub(crate) is_loopback: bool,
     pub(crate) ipv4: Vec<Ipv4Info>,
     pub(crate) ipv6: Vec<Ipv6Addr>,
@@ -48,11 +48,12 @@ pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
 
         let grouped = if let Some(existing) = interfaces.iter_mut().find(|g| g.name == iface.name)
         {
+            existing.is_loopback |= iface.is_loopback();
             existing
         } else {
             interfaces.push(GroupedInterface {
                 name: iface.name.clone(),
-                index: iface.index.unwrap_or(0),
+                index: iface.index,
                 is_loopback: iface.is_loopback(),
                 ipv4: Vec::new(),
                 ipv6: Vec::new(),
@@ -147,32 +148,42 @@ mod tests {
         (ipv6.segments()[0] & 0xffc0) == 0xfe80
     }
 
-    static DEFAULT_ADDR: LazyLock<DefaultAddr> = LazyLock::new(|| {
-        let addrs = if_addrs::get_if_addrs().expect("couldn't get network interfaces");
+    /// Determine the default IPv4 address using the UDP socket trick:
+    /// "connect" to a non-routable address and read back the source IP the OS chose.
+    fn get_default_ipv4() -> Option<Ipv4Addr> {
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+        socket.connect("10.254.254.254:1").ok()?;
+        match socket.local_addr().ok()?.ip() {
+            IpAddr::V4(ip) => Some(ip),
+            IpAddr::V6(_) => None,
+        }
+    }
 
-        // Only extract private / link-local addresses, since binding to others might fail in tests.
-        let active_non_loopback = || {
-            addrs
-                .iter()
-                .filter(|iface| !iface.is_loopback() && iface.is_oper_up())
-        };
+    static DEFAULT_ADDR: LazyLock<DefaultAddr> = LazyLock::new(|| {
+        // Use the UDP socket trick to find the default route's IPv4, matching
+        // the old netdev::get_default_interface() behaviour.
+        let default_ip = get_default_ipv4().expect("no default IPv4 route");
+
+        // Find which interface owns that IP, then grab its link-local IPv6 too.
+        // This guarantees both addresses come from the same interface.
+        let addrs = if_addrs::get_if_addrs().expect("couldn't get network interfaces");
+        let default_intf_name = &addrs
+            .iter()
+            .find(|iface| iface.ip() == IpAddr::V4(default_ip))
+            .expect("default IP not found on any interface")
+            .name;
 
         DefaultAddr {
-            v4: active_non_loopback()
-                .filter_map(|iface| match &iface.addr {
-                    if_addrs::IfAddr::V4(v4) => Some(v4.ip),
-                    _ => None,
-                })
-                .find(Ipv4Addr::is_private)
-                .expect("no private IPv4 address"),
-
-            v6: active_non_loopback()
+            v4: default_ip,
+            v6: addrs
+                .iter()
+                .filter(|iface| &iface.name == default_intf_name)
                 .filter_map(|iface| match &iface.addr {
                     if_addrs::IfAddr::V6(v6) => Some(v6.ip),
-                    _ => None,
+                    if_addrs::IfAddr::V4(_) => None,
                 })
                 .find(is_unicast_link_local)
-                .expect("no unique local IPv6 address"),
+                .expect("no link-local IPv6 on default interface"),
         }
     });
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -4,10 +4,9 @@
 pub use crate::client::{BoundDiscoveryClient, DiscoveryClient};
 #[cfg(feature = "server")]
 pub use crate::server::{BoundDiscoveryServer, DiscoveryServer};
-use netdev::Interface;
 use serde::{Deserialize, Serialize};
 use socket2::{Domain, Protocol, Socket, Type};
-use std::net::{Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 
 /// `ff12::a1:9aca` as per ASCOM Alpaca specification.
@@ -22,10 +21,61 @@ pub(crate) struct AlpacaPort {
     pub(crate) alpaca_port: u16,
 }
 
-pub(crate) fn get_active_interfaces() -> impl Iterator<Item = Interface> {
-    netdev::get_interfaces()
-        .into_iter()
-        .filter(Interface::is_running)
+/// IPv4 address information for a network interface.
+#[derive(Debug)]
+pub(crate) struct Ipv4Info {
+    pub(crate) addr: Ipv4Addr,
+    pub(crate) netmask: Ipv4Addr,
+}
+
+/// A network interface with all its IPv4 and IPv6 addresses grouped together.
+#[derive(Debug)]
+pub(crate) struct GroupedInterface {
+    pub(crate) name: String,
+    pub(crate) index: u32,
+    pub(crate) is_loopback: bool,
+    pub(crate) ipv4: Vec<Ipv4Info>,
+    pub(crate) ipv6: Vec<Ipv6Addr>,
+}
+
+pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
+    let mut interfaces: Vec<GroupedInterface> = Vec::new();
+
+    for iface in if_addrs::get_if_addrs()? {
+        if !iface.is_oper_up() {
+            continue;
+        }
+
+        let grouped = if let Some(existing) = interfaces.iter_mut().find(|g| g.name == iface.name)
+        {
+            existing
+        } else {
+            interfaces.push(GroupedInterface {
+                name: iface.name.clone(),
+                index: iface.index.unwrap_or(0),
+                is_loopback: iface.is_loopback(),
+                ipv4: Vec::new(),
+                ipv6: Vec::new(),
+            });
+            interfaces
+                .last_mut()
+                .expect("internal error: just pushed an element")
+        };
+
+        match iface.addr {
+            if_addrs::IfAddr::V4(v4) => {
+                grouped.ipv4.push(Ipv4Info {
+                    addr: v4.ip,
+                    netmask: v4.netmask,
+                });
+            }
+            if_addrs::IfAddr::V6(v6) => {
+                grouped.ipv6.push(v6.ip);
+            }
+        }
+    }
+
+    Ok(interfaces)
 }
 
 #[tracing::instrument(level = "trace")]
@@ -98,21 +148,29 @@ mod tests {
     }
 
     static DEFAULT_ADDR: LazyLock<DefaultAddr> = LazyLock::new(|| {
-        let intf = netdev::get_default_interface().expect("coudn't get default interface");
+        let addrs = if_addrs::get_if_addrs().expect("couldn't get network interfaces");
 
         // Only extract private / link-local addresses, since binding to others might fail in tests.
+        let active_non_loopback = || {
+            addrs
+                .iter()
+                .filter(|iface| !iface.is_loopback() && iface.is_oper_up())
+        };
+
         DefaultAddr {
-            v4: intf
-                .ipv4
-                .into_iter()
-                .map(|net| net.addr())
+            v4: active_non_loopback()
+                .filter_map(|iface| match &iface.addr {
+                    if_addrs::IfAddr::V4(v4) => Some(v4.ip),
+                    _ => None,
+                })
                 .find(Ipv4Addr::is_private)
                 .expect("no private IPv4 address"),
 
-            v6: intf
-                .ipv6
-                .into_iter()
-                .map(|net| net.addr())
+            v6: active_non_loopback()
+                .filter_map(|iface| match &iface.addr {
+                    if_addrs::IfAddr::V6(v6) => Some(v6.ip),
+                    _ => None,
+                })
                 .find(is_unicast_link_local)
                 .expect("no unique local IPv6 address"),
         }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -29,10 +29,17 @@ pub(crate) struct Ipv4Info {
 }
 
 /// A network interface with all its IPv4 and IPv6 addresses grouped together.
+///
+/// `ipv6_index` is populated only from V6 entries: on Windows, the V4 and V6
+/// interface indices for the same adapter can differ (`IfIndex` vs
+/// `Ipv6IfIndex` in `IP_ADAPTER_ADDRESSES`), and the IPv6 multicast APIs
+/// (`IPV6_MULTICAST_IF`, `IPV6_JOIN_GROUP`) need the V6-specific one. We don't
+/// store a V4 index because IPv4 discovery uses subnet-directed broadcast,
+/// where the routing table picks the outbound interface by destination.
 #[derive(Debug)]
 pub(crate) struct GroupedInterface {
     pub(crate) name: String,
-    pub(crate) index: Option<u32>,
+    pub(crate) ipv6_index: Option<u32>,
     pub(crate) is_loopback: bool,
     pub(crate) ipv4: Vec<Ipv4Info>,
     pub(crate) ipv6: Vec<Ipv6Addr>,
@@ -49,12 +56,11 @@ pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
         let grouped = if let Some(existing) = interfaces.iter_mut().find(|g| g.name == iface.name)
         {
             existing.is_loopback |= iface.is_loopback();
-            existing.index = existing.index.or(iface.index);
             existing
         } else {
             interfaces.push(GroupedInterface {
                 name: iface.name.clone(),
-                index: iface.index,
+                ipv6_index: None,
                 is_loopback: iface.is_loopback(),
                 ipv4: Vec::new(),
                 ipv6: Vec::new(),
@@ -72,6 +78,7 @@ pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
                 });
             }
             if_addrs::IfAddr::V6(v6) => {
+                grouped.ipv6_index = grouped.ipv6_index.or(iface.index);
                 grouped.ipv6.push(v6.ip);
             }
         }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -49,6 +49,7 @@ pub(crate) fn get_active_interfaces() -> eyre::Result<Vec<GroupedInterface>> {
         let grouped = if let Some(existing) = interfaces.iter_mut().find(|g| g.name == iface.name)
         {
             existing.is_loopback |= iface.is_loopback();
+            existing.index = existing.index.or(iface.index);
             existing
         } else {
             interfaces.push(GroupedInterface {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -163,8 +163,8 @@ mod tests {
     /// RFC1918 prefixes, which would make a `10.0.0.0/8` target resolve to
     /// the VPN interface instead of the true default route.
     fn get_default_ipv4() -> Option<Ipv4Addr> {
-        let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-        socket.connect("192.0.2.1:1").ok()?;
+        let socket = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+        socket.connect("192.0.2.1:0").ok()?;
         match socket.local_addr().ok()?.ip() {
             IpAddr::V4(ip) => Some(ip),
             IpAddr::V6(_) => None,

--- a/src/server/discovery.rs
+++ b/src/server/discovery.rs
@@ -18,7 +18,11 @@ pub struct Server {
 
 #[tracing::instrument(level = "trace", skip_all, fields(intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
 fn join_multicast_group(socket: &UdpSocket, intf: &GroupedInterface) {
-    match socket.join_multicast_v6(&DISCOVERY_ADDR_V6, intf.index) {
+    let Some(index) = intf.index else {
+        tracing::warn!("skipping multicast join: no interface index");
+        return;
+    };
+    match socket.join_multicast_v6(&DISCOVERY_ADDR_V6, index) {
         Ok(()) => tracing::trace!("success"),
         Err(err) => tracing::warn!(%err),
     }

--- a/src/server/discovery.rs
+++ b/src/server/discovery.rs
@@ -28,15 +28,9 @@ fn join_multicast_group(socket: &UdpSocket, intf: &GroupedInterface) {
     }
 }
 
-#[tracing::instrument(level = "debug", ret, skip(socket))]
-fn join_multicast_groups(socket: &UdpSocket, listen_addr: Ipv6Addr) {
-    let interfaces = match get_active_interfaces() {
-        Ok(interfaces) => interfaces,
-        Err(err) => {
-            tracing::warn!(%err, "failed to get network interfaces");
-            return;
-        }
-    };
+#[tracing::instrument(level = "debug", skip(socket))]
+fn join_multicast_groups(socket: &UdpSocket, listen_addr: Ipv6Addr) -> eyre::Result<()> {
+    let interfaces = get_active_interfaces()?;
 
     if listen_addr.is_unspecified() {
         // If it's [::], join multicast on every available interface with IPv6 support.
@@ -54,6 +48,8 @@ fn join_multicast_groups(socket: &UdpSocket, listen_addr: Ipv6Addr) {
 
         join_multicast_group(socket, intf);
     }
+
+    Ok(())
 }
 
 impl Server {
@@ -78,10 +74,10 @@ impl Server {
             // Both if_addrs::get_if_addrs and join_multicast_group can take a long time.
             // Spawn them all off to the async runtime.
             socket = spawn_blocking(move || {
-                join_multicast_groups(&socket, listen_addr);
-                socket
+                join_multicast_groups(&socket, listen_addr)?;
+                Ok::<_, eyre::Report>(socket)
             })
-            .await?;
+            .await??;
         }
         Ok(BoundServer {
             socket,

--- a/src/server/discovery.rs
+++ b/src/server/discovery.rs
@@ -1,8 +1,8 @@
 use super::DEFAULT_DISCOVERY_PORT;
 use crate::discovery::{
-    AlpacaPort, DISCOVERY_ADDR_V6, DISCOVERY_MSG, bind_socket, get_active_interfaces,
+    AlpacaPort, DISCOVERY_ADDR_V6, DISCOVERY_MSG, GroupedInterface, bind_socket,
+    get_active_interfaces,
 };
-use netdev::Interface;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 use tokio::task::spawn_blocking;
@@ -16,8 +16,8 @@ pub struct Server {
     pub alpaca_port: u16,
 }
 
-#[tracing::instrument(level = "trace", skip_all, fields(intf.friendly_name = intf.friendly_name.as_ref(), intf.description = intf.description.as_ref(), ?intf.ipv4, ?intf.ipv6))]
-fn join_multicast_group(socket: &UdpSocket, intf: &Interface) {
+#[tracing::instrument(level = "trace", skip_all, fields(intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
+fn join_multicast_group(socket: &UdpSocket, intf: &GroupedInterface) {
     match socket.join_multicast_v6(&DISCOVERY_ADDR_V6, intf.index) {
         Ok(()) => tracing::trace!("success"),
         Err(err) => tracing::warn!(%err),
@@ -26,20 +26,29 @@ fn join_multicast_group(socket: &UdpSocket, intf: &Interface) {
 
 #[tracing::instrument(level = "debug", ret, skip(socket))]
 fn join_multicast_groups(socket: &UdpSocket, listen_addr: Ipv6Addr) {
+    let interfaces = match get_active_interfaces() {
+        Ok(interfaces) => interfaces,
+        Err(err) => {
+            tracing::warn!(%err, "failed to get network interfaces");
+            return;
+        }
+    };
+
     if listen_addr.is_unspecified() {
         // If it's [::], join multicast on every available interface with IPv6 support.
-        for intf in get_active_interfaces() {
+        for intf in &interfaces {
             if !intf.ipv6.is_empty() {
-                join_multicast_group(socket, &intf);
+                join_multicast_group(socket, intf);
             }
         }
     } else {
         // If it's a specific address, find corresponding interface and join multicast on it.
-        let intf = get_active_interfaces()
-            .find(|intf| intf.ipv6.iter().any(|net| net.addr() == listen_addr))
+        let intf = interfaces
+            .iter()
+            .find(|intf| intf.ipv6.contains(&listen_addr))
             .expect("internal error: couldn't find the interface of an already bound socket");
 
-        join_multicast_group(socket, &intf);
+        join_multicast_group(socket, intf);
     }
 }
 
@@ -62,7 +71,7 @@ impl Server {
     pub async fn bind(self) -> eyre::Result<BoundServer> {
         let mut socket = bind_socket(self.listen_addr)?;
         if let IpAddr::V6(listen_addr) = self.listen_addr.ip() {
-            // Both netdev::get_interfaces and join_multicast_group can take a long time.
+            // Both if_addrs::get_if_addrs and join_multicast_group can take a long time.
             // Spawn them all off to the async runtime.
             socket = spawn_blocking(move || {
                 join_multicast_groups(&socket, listen_addr);

--- a/src/server/discovery.rs
+++ b/src/server/discovery.rs
@@ -18,8 +18,8 @@ pub struct Server {
 
 #[tracing::instrument(level = "trace", skip_all, fields(intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
 fn join_multicast_group(socket: &UdpSocket, intf: &GroupedInterface) {
-    let Some(index) = intf.index else {
-        tracing::warn!("skipping multicast join: no interface index");
+    let Some(index) = intf.ipv6_index else {
+        tracing::warn!("skipping multicast join: no IPv6 interface index");
         return;
     };
     match socket.join_multicast_v6(&DISCOVERY_ADDR_V6, index) {

--- a/src/server/discovery.rs
+++ b/src/server/discovery.rs
@@ -16,8 +16,8 @@ pub struct Server {
     pub alpaca_port: u16,
 }
 
-#[tracing::instrument(level = "trace", skip_all, fields(intf.name = %intf.name, ?intf.ipv4, ?intf.ipv6))]
-fn join_multicast_group(socket: &UdpSocket, intf: &GroupedInterface) {
+#[tracing::instrument(level = "trace", skip_all, fields(intf.name = %name, ?intf.ipv4, ?intf.ipv6))]
+fn join_multicast_group(socket: &UdpSocket, name: &str, intf: &GroupedInterface) {
     let Some(index) = intf.ipv6_index else {
         tracing::warn!("skipping multicast join: no IPv6 interface index");
         return;
@@ -34,19 +34,19 @@ fn join_multicast_groups(socket: &UdpSocket, listen_addr: Ipv6Addr) -> eyre::Res
 
     if listen_addr.is_unspecified() {
         // If it's [::], join multicast on every available interface with IPv6 support.
-        for intf in &interfaces {
+        for (name, intf) in &interfaces {
             if !intf.ipv6.is_empty() {
-                join_multicast_group(socket, intf);
+                join_multicast_group(socket, name, intf);
             }
         }
     } else {
         // If it's a specific address, find corresponding interface and join multicast on it.
-        let intf = interfaces
+        let (name, intf) = interfaces
             .iter()
-            .find(|intf| intf.ipv6.contains(&listen_addr))
+            .find(|(_, intf)| intf.ipv6.contains(&listen_addr))
             .expect("internal error: couldn't find the interface of an already bound socket");
 
-        join_multicast_group(socket, intf);
+        join_multicast_group(socket, name, intf);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Replaces the `netdev` dependency with `if-addrs` to fix a trait recursion overflow that prevents compilation on macOS.

## Problem

`netdev` transitively depends on `objc2`, which defines a blanket `IntoIterator` impl for `&Retained<T>`. This causes infinite trait recursion when the Rust trait solver evaluates `serde_ndim`'s `NDim: IntoIterator` bound during compilation of the camera image array serialization code. This is a known Rust compiler issue ([rust-lang/rust#136856](https://github.com/rust-lang/rust/issues/136856)).

## Solution

`if-addrs` provides the same network interface enumeration functionality using only `libc` (unix) / `windows-sys` (windows) — no objc2 dependency chain. This eliminates the root cause entirely.

The main adaptation is a `GroupedInterface` struct that re-groups `if-addrs`' per-address entries by interface name, since `if-addrs` returns one entry per address while the discovery code expects one entry per interface.

## Motivation

This blocks running CI on macOS. The crate does not compile on macOS at all with the current `netdev` dependency.

## Changes

- `Cargo.toml`: Replace `netdev` with `if-addrs`
- `src/discovery.rs`: Add `GroupedInterface` struct with `get_active_interfaces()` function; merge interface index across address entries so multicast isn't skipped when the first entry lacks an index
- `src/client/discovery.rs`: Adapt to `GroupedInterface` API
- `src/server/discovery.rs`: Adapt to `GroupedInterface` API, improve multi-homed network handling
- `Cargo.lock`: Updated

## Test plan

- [x] `cargo clippy` passes (full CI feature matrix verified on Linux)
- [ ] Compiles on macOS
- [ ] Discovery still works on multi-homed hosts
- [ ] Loopback interfaces correctly excluded from discovery