### PR TITLE
Make discovery server optional via Option<u16> port

### DIFF
--- a/examples/camera-server/src/main.rs
+++ b/examples/camera-server/src/main.rs
@@ -587,7 +587,7 @@ fn get_webcam(camera_info: &CameraInfo) -> eyre::Result<Webcam> {
             let bin_x = exact_div(max_format_res.x, format_res.x)?;
             let bin_y = exact_div(max_format_res.y, format_res.y)?;
 
-            (bin_x == bin_y).then_some(bin_x as u8)
+            (bin_x == bin_y).then_some(bin_x)
         })
         .collect::<Vec<_>>();
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -15,7 +15,8 @@ use tokio::net::UdpSocket;
 /// `ff12::a1:9aca` as per ASCOM Alpaca specification.
 pub(crate) const DISCOVERY_ADDR_V6: Ipv6Addr = Ipv6Addr::new(0xff12, 0, 0, 0, 0, 0, 0xa1, 0x9aca);
 pub(crate) const DISCOVERY_MSG: &[u8] = b"alpacadiscovery1";
-pub(crate) const DEFAULT_DISCOVERY_PORT: u16 = 32227;
+/// Default ASCOM Alpaca discovery port as defined by the specification.
+pub const DEFAULT_DISCOVERY_PORT: u16 = 32227;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct AlpacaPort {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -55,8 +55,9 @@ pub struct Server {
     pub listen_addr: SocketAddr,
     /// Port for the discovery server to listen on.
     ///
-    /// Defaults to 32227.
-    pub discovery_port: u16,
+    /// Defaults to `Some(32227)`. Set to `None` to disable the discovery server
+    /// (useful in tests or environments where discovery is not needed).
+    pub discovery_port: Option<u16>,
 }
 
 impl Server {
@@ -75,7 +76,7 @@ impl Server {
             devices: Devices::default(),
             info,
             listen_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
-            discovery_port: DEFAULT_DISCOVERY_PORT,
+            discovery_port: Some(DEFAULT_DISCOVERY_PORT),
         }
     }
 }
@@ -136,7 +137,7 @@ pub struct BoundServer {
     #[debug(skip)]
     axum: BoxFuture<'static, eyre::Result<std::convert::Infallible>>,
     axum_listen_addr: SocketAddr,
-    discovery: BoundDiscoveryServer,
+    discovery: Option<BoundDiscoveryServer>,
 }
 
 impl BoundServer {
@@ -146,9 +147,10 @@ impl BoundServer {
         self.axum_listen_addr
     }
 
-    /// Returns the address the discovery server is listening on.
-    pub fn discovery_listen_addr(&self) -> SocketAddr {
-        self.discovery.listen_addr()
+    /// Returns the address the discovery server is listening on,
+    /// or `None` if discovery is disabled.
+    pub fn discovery_listen_addr(&self) -> Option<SocketAddr> {
+        self.discovery.as_ref().map(|d| d.listen_addr())
     }
 
     /// Starts the Alpaca and discovery servers.
@@ -156,10 +158,14 @@ impl BoundServer {
     /// Note: this function starts an infinite async loop and it's your responsibility to spawn it off
     /// via [`tokio::spawn`] if necessary.
     pub async fn start(self) -> eyre::Result<std::convert::Infallible> {
-        match tokio::select! {
-            axum = self.axum => axum?,
-            discovery = self.discovery.start() => discovery,
-        } {}
+        if let Some(discovery) = self.discovery {
+            match tokio::select! {
+                axum = self.axum => axum?,
+                discovery = discovery.start() => discovery,
+            } {}
+        } else {
+            match self.axum.await? {}
+        }
     }
 }
 
@@ -203,11 +209,16 @@ impl Server {
 
         // Bind discovery server only once the Alpaca server is bound successfully.
         // We need to know the bound address & the port to advertise.
-        let discovery_server = DiscoveryServer::for_alpaca_server_at(bound_addr)
-            .bind()
-            .await?;
-
-        tracing::debug!("Bound Alpaca discovery server");
+        let discovery_server = if let Some(port) = self.discovery_port {
+            let mut discovery = DiscoveryServer::for_alpaca_server_at(bound_addr);
+            discovery.listen_addr.set_port(port);
+            let bound = discovery.bind().await?;
+            tracing::debug!("Bound Alpaca discovery server");
+            Some(bound)
+        } else {
+            tracing::debug!("Discovery server disabled");
+            None
+        };
 
         Ok(BoundServer {
             axum: async move {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -150,7 +150,9 @@ impl BoundServer {
     /// Returns the address the discovery server is listening on,
     /// or `None` if discovery is disabled.
     pub fn discovery_listen_addr(&self) -> Option<SocketAddr> {
-        self.discovery.as_ref().map(discovery::BoundServer::listen_addr)
+        self.discovery
+            .as_ref()
+            .map(discovery::BoundServer::listen_addr)
     }
 
     /// Starts the Alpaca and discovery servers.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -150,7 +150,7 @@ impl BoundServer {
     /// Returns the address the discovery server is listening on,
     /// or `None` if discovery is disabled.
     pub fn discovery_listen_addr(&self) -> Option<SocketAddr> {
-        self.discovery.as_ref().map(|d| d.listen_addr())
+        self.discovery.as_ref().map(discovery::BoundServer::listen_addr)
     }
 
     /// Starts the Alpaca and discovery servers.
@@ -158,13 +158,14 @@ impl BoundServer {
     /// Note: this function starts an infinite async loop and it's your responsibility to spawn it off
     /// via [`tokio::spawn`] if necessary.
     pub async fn start(self) -> eyre::Result<std::convert::Infallible> {
-        if let Some(discovery) = self.discovery {
-            match tokio::select! {
-                axum = self.axum => axum?,
-                discovery = discovery.start() => discovery,
-            } {}
-        } else {
-            match self.axum.await? {}
+        match self.discovery {
+            Some(discovery) => {
+                match tokio::select! {
+                    axum = self.axum => axum?,
+                    discovery = discovery.start() => discovery,
+                } {}
+            }
+            None => match self.axum.await? {},
         }
     }
 }


### PR DESCRIPTION
## Summary

Changes `Server`'s discovery port from `u16` to `Option<u16>`, allowing the discovery server to be disabled entirely by passing `None`. Also makes `DEFAULT_DISCOVERY_PORT` public so consumers can reference it.

## Motivation

When running multiple Alpaca servers in integration tests, each server tries to bind the discovery UDP socket, causing port conflicts. Making the discovery server optional allows test servers to skip discovery binding entirely, avoiding these conflicts.

## Changes

- `src/server/mod.rs`:
  - `Server::discovery_port` changed from `u16` to `Option<u16>`
  - `BoundServer::discovery` changed from `BoundDiscoveryServer` to `Option<BoundDiscoveryServer>`
  - `BoundServer::discovery_listen_addr()` returns `Option<SocketAddr>`
  - `BoundServer::start()` restructured to handle both cases
- `src/discovery.rs`: `DEFAULT_DISCOVERY_PORT` changed from `pub(crate)` to `pub` with documentation

## Test plan

- [x] `cargo clippy` passes (full CI feature matrix verified)
- [ ] `Server::new(...)` with `Some(port)` behaves identically to before
- [ ] `Server::new(...)` with `None` skips discovery server entirely
- [ ] `DEFAULT_DISCOVERY_PORT` accessible from downstream crates