### PR TITLE
fix(client): handle unaligned ImageBytes response buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ axum = { version = "0.8.8", optional = true }
 bytemuck = { version = "1.24.0", features = [
 	"derive",
 	"extern_crate_std",
+	"must_cast",
 ], optional = true }
 criterion = { version = "0.8.1", optional = true }
 derive_more = { workspace = true, features = [

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -82,25 +82,35 @@ impl<'de> Deserialize<'de> for JsonImageArray {
     }
 }
 
-fn cast_raw_data<T: AsTransmissionElementType + bytemuck::NoUninit>(
-    data: &[u8],
-) -> Result<Vec<i32>, PodCastError> {
-    // Fast path: if `data` happens to be aligned to `align_of::<T>()`,
-    // `try_cast_slice` reinterprets in place and we just iterate.
+fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, PodCastError> {
+    // Fast path: if `data` is already aligned to `align_of::<T>()`,
+    // `try_cast_slice` reinterprets in place and we iterate-and-widen
+    // into the output `Vec<i32>`. This is the common case — most host
+    // allocators hand out 16-aligned buffers so the body slice that
+    // reqwest hands us satisfies a 4-byte alignment requirement.
     //
-    // Slow path: the HTTP response body that backs `data` is a
-    // `bytes::Bytes` slice from reqwest's chunked read, and its start
-    // pointer is not guaranteed to be `align_of::<T>()`-aligned (4
-    // bytes for `i32`, 2 for `i16`/`u16`). When the fast cast fails
-    // with `TargetAlignmentGreaterAndInputNotAligned`, copy through
-    // an aligned `Vec<T>` via `pod_collect_to_vec`. Length-mismatch /
-    // slop errors propagate verbatim — only the alignment failure
-    // gets the unaligned fallback.
+    // Slow path: the HTTP response body is a `bytes::Bytes` slice
+    // from reqwest's chunked read, and its start pointer is not
+    // *guaranteed* to be `align_of::<T>()`-aligned (4 bytes for
+    // `i32`, 2 for `i16` / `u16`). When the fast cast fails with
+    // `TargetAlignmentGreaterAndInputNotAligned`, decode each chunk
+    // via `T::widen_from_le_chunk` straight into the output
+    // `Vec<i32>` — one pass, no intermediate aligned `Vec<T>`.
+    // Memory ceiling on the slow path is `sizeof_output` rather
+    // than `data.len() + sizeof_output`. Length-mismatch / slop
+    // errors propagate verbatim — only the alignment failure gets
+    // the unaligned fallback.
     match bytemuck::try_cast_slice::<u8, T>(data) {
         Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
         Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
-            let owned: Vec<T> = bytemuck::pod_collect_to_vec(data);
-            Ok(owned.into_iter().map(T::into).collect())
+            let elem_size = size_of::<T>();
+            if !data.len().is_multiple_of(elem_size) {
+                return Err(PodCastError::OutputSliceWouldHaveSlop);
+            }
+            Ok(data
+                .chunks_exact(elem_size)
+                .map(T::widen_from_le_chunk)
+                .collect())
         }
         Err(other) => Err(other),
     }

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -85,20 +85,25 @@ impl<'de> Deserialize<'de> for JsonImageArray {
 fn cast_raw_data<T: AsTransmissionElementType + bytemuck::NoUninit>(
     data: &[u8],
 ) -> Result<Vec<i32>, PodCastError> {
-    // `bytemuck::try_cast_slice::<u8, T>` requires the source pointer
-    // to be aligned to `align_of::<T>()`. The HTTP response body that
-    // backs `data` is a `bytes::Bytes` slice from reqwest's chunked
-    // read — its start pointer is not guaranteed to be 4-byte aligned
-    // (or 2-byte aligned for `i16` / `u16`). Copy through an aligned
-    // `Vec<T>` instead so callers don't see intermittent
-    // `TargetAlignmentGreaterAndInputNotAligned` failures dependent on
-    // the host allocator's runtime behaviour.
-    let elem_size = size_of::<T>();
-    if data.len() % elem_size != 0 {
-        return Err(PodCastError::OutputSliceWouldHaveSlop);
+    // Fast path: if `data` happens to be aligned to `align_of::<T>()`,
+    // `try_cast_slice` reinterprets in place and we just iterate.
+    //
+    // Slow path: the HTTP response body that backs `data` is a
+    // `bytes::Bytes` slice from reqwest's chunked read, and its start
+    // pointer is not guaranteed to be `align_of::<T>()`-aligned (4
+    // bytes for `i32`, 2 for `i16`/`u16`). When the fast cast fails
+    // with `TargetAlignmentGreaterAndInputNotAligned`, copy through
+    // an aligned `Vec<T>` via `pod_collect_to_vec`. Length-mismatch /
+    // slop errors propagate verbatim — only the alignment failure
+    // gets the unaligned fallback.
+    match bytemuck::try_cast_slice::<u8, T>(data) {
+        Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
+        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
+            let owned: Vec<T> = bytemuck::pod_collect_to_vec(data);
+            Ok(owned.into_iter().map(T::into).collect())
+        }
+        Err(other) => Err(other),
     }
-    let aligned: Vec<T> = bytemuck::pod_collect_to_vec(data);
-    Ok(aligned.into_iter().map(T::into).collect())
 }
 
 impl Response for ASCOMResult<ImageArray> {
@@ -123,11 +128,12 @@ impl Response for ASCOMResult<ImageArray> {
             .get(..size_of::<ImageBytesMetadata>())
             .ok_or_else(|| eyre::eyre!("not enough bytes to read image metadata"))?;
         // `bytemuck::try_from_bytes::<ImageBytesMetadata>` requires
-        // the source slice to be aligned to `align_of::<i32>() == 4`.
-        // The body buffer's start pointer is not guaranteed to be
-        // 4-aligned (see `cast_raw_data` for the parallel issue);
+        // the source slice to be aligned to
+        // `align_of::<ImageBytesMetadata>()`. The body buffer's start
+        // pointer is not guaranteed to satisfy that (see
+        // `cast_raw_data` for the parallel issue);
         // `pod_read_unaligned` reads via `ptr::read_unaligned` and
-        // is safe for any pointer.
+        // works for any pointer.
         let metadata: ImageBytesMetadata = bytemuck::pod_read_unaligned(metadata_bytes);
         eyre::ensure!(
             metadata.metadata_version == 1_i32,
@@ -191,34 +197,36 @@ mod tests {
     use super::*;
 
     /// Build an `application/imagebytes` payload at the given byte
-    /// offset within a `Vec<u8>`. The returned slice's start pointer
-    /// has the requested alignment-mod-4. Used to reproduce the
-    /// upstream-pre-fix `TargetAlignmentGreaterAndInputNotAligned`
-    /// path, which only fires when the buffer slice is not 4-byte
-    /// aligned.
+    /// offset within a `Vec<u8>`. The `Vec`'s base allocation is
+    /// usually a high-alignment chunk from the system allocator, so
+    /// looping `leading_pad` over `0..align_of::<i32>()` is sufficient
+    /// to cover all four `mod 4` cases — at least three of those
+    /// rotations land the body slice on a non-4-aligned start, which
+    /// is what reproduces the upstream-pre-fix
+    /// `TargetAlignmentGreaterAndInputNotAligned` path.
     fn imagebytes_payload_at_offset(
         leading_pad: usize,
         pixels: &[i32],
-    ) -> (Vec<u8>, std::ops::Range<usize>) {
+    ) -> eyre::Result<(Vec<u8>, std::ops::Range<usize>)> {
         let metadata = ImageBytesMetadata {
-            metadata_version: 1,
-            error_number: 0,
+            metadata_version: 1_i32,
+            error_number: 0_i32,
             client_transaction_id: None,
             server_transaction_id: None,
-            data_start: i32::try_from(size_of::<ImageBytesMetadata>()).unwrap(),
-            image_element_type: TransmissionElementType::I32 as i32,
-            transmission_element_type: TransmissionElementType::I32 as i32,
-            rank: ImageArrayRank::Rank2 as i32,
-            dimension_1: i32::try_from(pixels.len()).unwrap(),
-            dimension_2: 1,
-            dimension_3: 0,
+            data_start: i32::try_from(size_of::<ImageBytesMetadata>())?,
+            image_element_type: i32::from(TransmissionElementType::I32),
+            transmission_element_type: i32::from(TransmissionElementType::I32),
+            rank: i32::from(ImageArrayRank::Rank2),
+            dimension_1: i32::try_from(pixels.len())?,
+            dimension_2: 1_i32,
+            dimension_3: 0_i32,
         };
         let mut buf = vec![0u8; leading_pad];
         let payload_start = buf.len();
         buf.extend_from_slice(bytemuck::bytes_of(&metadata));
         buf.extend_from_slice(bytemuck::cast_slice(pixels));
         let payload_end = buf.len();
-        (buf, payload_start..payload_end)
+        Ok((buf, payload_start..payload_end))
     }
 
     /// Regression test for issue #18: parsing an `imagebytes` body
@@ -229,25 +237,36 @@ mod tests {
     /// `try_cast_slice` require source alignment. After the fix —
     /// using `pod_read_unaligned` and `pod_collect_to_vec` — the
     /// parse is alignment-independent.
+    fn check_one_offset(leading_pad: usize, pixels: &[i32]) -> eyre::Result<()> {
+        let (buf, range) = imagebytes_payload_at_offset(leading_pad, pixels)?;
+        let slice = &buf[range];
+        let mime: Mime = IMAGE_BYTES_TYPE.parse()?;
+        let parsed = <ASCOMResult<ImageArray> as Response>::from_reqwest(mime, slice)?;
+        let array = parsed
+            .response
+            .map_err(|e| eyre::eyre!("ascom error: {e:?}"))?;
+        eyre::ensure!(
+            array.shape() == [pixels.len(), 1_usize, 1_usize],
+            "shape mismatch: {:?}",
+            array.shape()
+        );
+        for (i, &p) in pixels.iter().enumerate() {
+            let actual = array[[i, 0_usize, 0_usize]];
+            eyre::ensure!(actual == p, "pixel {i} mismatch: got {actual}, expected {p}");
+        }
+        Ok(())
+    }
+
     #[test]
     fn from_reqwest_handles_unaligned_imagebytes_slice() {
-        let pixels: Vec<i32> = (0..16).collect();
-        // Try every offset 0..4 — at least one of 1, 2, 3 is
-        // guaranteed to put the body slice on a non-4-aligned start
-        // even if `Vec<u8>` happens to allocate at a 4-aligned base.
-        for leading_pad in 0..4 {
-            let (buf, range) = imagebytes_payload_at_offset(leading_pad, &pixels);
-            let slice = &buf[range];
-            let mime: Mime = IMAGE_BYTES_TYPE.parse().unwrap();
-            let parsed =
-                <ASCOMResult<ImageArray> as Response>::from_reqwest(mime, slice).unwrap_or_else(
-                    |e| panic!("from_reqwest failed at leading_pad={leading_pad}: {e:?}"),
-                );
-            let array = parsed.response.unwrap();
-            assert_eq!(array.shape(), &[pixels.len(), 1, 1]);
-            for (i, &p) in pixels.iter().enumerate() {
-                assert_eq!(array[[i, 0, 0]], p, "pixel {i} mismatch");
-            }
+        let pixels: Vec<i32> = (0_i32..16_i32).collect();
+        // Try every offset 0..4 — at least three of these rotations
+        // land the body slice on a non-4-aligned start (regardless of
+        // the `Vec<u8>` base alignment), which is the case that fails
+        // pre-fix.
+        for leading_pad in 0_usize..4_usize {
+            check_one_offset(leading_pad, &pixels)
+                .unwrap_or_else(|e| panic!("leading_pad={leading_pad}: {e:?}"));
         }
     }
 }

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -82,12 +82,23 @@ impl<'de> Deserialize<'de> for JsonImageArray {
     }
 }
 
-fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, PodCastError> {
-    Ok(bytemuck::try_cast_slice::<u8, T>(data)?
-        .iter()
-        .copied()
-        .map(T::into)
-        .collect())
+fn cast_raw_data<T: AsTransmissionElementType + bytemuck::NoUninit>(
+    data: &[u8],
+) -> Result<Vec<i32>, PodCastError> {
+    // `bytemuck::try_cast_slice::<u8, T>` requires the source pointer
+    // to be aligned to `align_of::<T>()`. The HTTP response body that
+    // backs `data` is a `bytes::Bytes` slice from reqwest's chunked
+    // read — its start pointer is not guaranteed to be 4-byte aligned
+    // (or 2-byte aligned for `i16` / `u16`). Copy through an aligned
+    // `Vec<T>` instead so callers don't see intermittent
+    // `TargetAlignmentGreaterAndInputNotAligned` failures dependent on
+    // the host allocator's runtime behaviour.
+    let elem_size = size_of::<T>();
+    if data.len() % elem_size != 0 {
+        return Err(PodCastError::OutputSliceWouldHaveSlop);
+    }
+    let aligned: Vec<T> = bytemuck::pod_collect_to_vec(data);
+    Ok(aligned.into_iter().map(T::into).collect())
 }
 
 impl Response for ASCOMResult<ImageArray> {
@@ -108,10 +119,16 @@ impl Response for ASCOMResult<ImageArray> {
                 },
             });
         }
-        let metadata = bytes
+        let metadata_bytes = bytes
             .get(..size_of::<ImageBytesMetadata>())
             .ok_or_else(|| eyre::eyre!("not enough bytes to read image metadata"))?;
-        let metadata = bytemuck::try_from_bytes::<ImageBytesMetadata>(metadata)?;
+        // `bytemuck::try_from_bytes::<ImageBytesMetadata>` requires
+        // the source slice to be aligned to `align_of::<i32>() == 4`.
+        // The body buffer's start pointer is not guaranteed to be
+        // 4-aligned (see `cast_raw_data` for the parallel issue);
+        // `pod_read_unaligned` reads via `ptr::read_unaligned` and
+        // is safe for any pointer.
+        let metadata: ImageBytesMetadata = bytemuck::pod_read_unaligned(metadata_bytes);
         eyre::ensure!(
             metadata.metadata_version == 1_i32,
             "unsupported metadata version {}",
@@ -166,5 +183,71 @@ impl Response for ASCOMResult<ImageArray> {
             transaction,
             response: ascom_result,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an `application/imagebytes` payload at the given byte
+    /// offset within a `Vec<u8>`. The returned slice's start pointer
+    /// has the requested alignment-mod-4. Used to reproduce the
+    /// upstream-pre-fix `TargetAlignmentGreaterAndInputNotAligned`
+    /// path, which only fires when the buffer slice is not 4-byte
+    /// aligned.
+    fn imagebytes_payload_at_offset(
+        leading_pad: usize,
+        pixels: &[i32],
+    ) -> (Vec<u8>, std::ops::Range<usize>) {
+        let metadata = ImageBytesMetadata {
+            metadata_version: 1,
+            error_number: 0,
+            client_transaction_id: None,
+            server_transaction_id: None,
+            data_start: i32::try_from(size_of::<ImageBytesMetadata>()).unwrap(),
+            image_element_type: TransmissionElementType::I32 as i32,
+            transmission_element_type: TransmissionElementType::I32 as i32,
+            rank: ImageArrayRank::Rank2 as i32,
+            dimension_1: i32::try_from(pixels.len()).unwrap(),
+            dimension_2: 1,
+            dimension_3: 0,
+        };
+        let mut buf = vec![0u8; leading_pad];
+        let payload_start = buf.len();
+        buf.extend_from_slice(bytemuck::bytes_of(&metadata));
+        buf.extend_from_slice(bytemuck::cast_slice(pixels));
+        let payload_end = buf.len();
+        (buf, payload_start..payload_end)
+    }
+
+    /// Regression test for issue #18: parsing an `imagebytes` body
+    /// whose slice start is not 4-byte aligned must succeed.
+    /// Pre-fix this path failed with
+    /// `bytemuck::PodCastError::TargetAlignmentGreaterAndInputNotAligned`
+    /// because both the metadata `try_from_bytes` and the pixel
+    /// `try_cast_slice` require source alignment. After the fix —
+    /// using `pod_read_unaligned` and `pod_collect_to_vec` — the
+    /// parse is alignment-independent.
+    #[test]
+    fn from_reqwest_handles_unaligned_imagebytes_slice() {
+        let pixels: Vec<i32> = (0..16).collect();
+        // Try every offset 0..4 — at least one of 1, 2, 3 is
+        // guaranteed to put the body slice on a non-4-aligned start
+        // even if `Vec<u8>` happens to allocate at a 4-aligned base.
+        for leading_pad in 0..4 {
+            let (buf, range) = imagebytes_payload_at_offset(leading_pad, &pixels);
+            let slice = &buf[range];
+            let mime: Mime = IMAGE_BYTES_TYPE.parse().unwrap();
+            let parsed =
+                <ASCOMResult<ImageArray> as Response>::from_reqwest(mime, slice).unwrap_or_else(
+                    |e| panic!("from_reqwest failed at leading_pad={leading_pad}: {e:?}"),
+                );
+            let array = parsed.response.unwrap();
+            assert_eq!(array.shape(), &[pixels.len(), 1, 1]);
+            for (i, &p) in pixels.iter().enumerate() {
+                assert_eq!(array[[i, 0, 0]], p, "pixel {i} mismatch");
+            }
+        }
     }
 }

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -1,6 +1,6 @@
 use super::{
-    AsTransmissionElementType, ImageArray, ImageArrayRank, ImageBytesMetadata, ImageElementType,
-    TransmissionElementType, COLOUR_AXIS, IMAGE_BYTES_TYPE,
+    AsTransmissionElementType, COLOUR_AXIS, IMAGE_BYTES_TYPE, ImageArray, ImageArrayRank,
+    ImageBytesMetadata, ImageElementType, TransmissionElementType,
 };
 use crate::client::{Response, ResponseTransaction, ResponseWithTransaction};
 use crate::{ASCOMError, ASCOMErrorCode, ASCOMResult};
@@ -8,8 +8,8 @@ use bytemuck::PodCastError;
 use mime::Mime;
 use ndarray::{Array2, Array3};
 use num_enum::TryFromPrimitive;
-use serde::de::{DeserializeOwned, IgnoredAny, MapAccess, Visitor};
 use serde::Deserialize;
+use serde::de::{DeserializeOwned, IgnoredAny, MapAccess, Visitor};
 use serde_ndim::de::MakeNDim;
 use std::fmt::{self, Formatter};
 
@@ -103,7 +103,17 @@ fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, 
     // propagate verbatim — only the alignment failure falls back.
     match bytemuck::try_cast_slice::<u8, T>(data) {
         Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
-        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => T::widen_unaligned(data),
+        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
+            // Read as unaligned byte blobs of the same size as `T`.
+            Ok(bytemuck::try_cast_slice::<u8, T::Bytes>(data)?
+                .iter()
+                .copied()
+                // Then reinterpret each byte blob as `T`.
+                .map(bytemuck::must_cast)
+                // And convert to the target `i32`.
+                .map(T::into)
+                .collect())
+        }
         Err(other) => Err(other),
     }
 }
@@ -255,7 +265,10 @@ mod tests {
         );
         for (i, &p) in pixels.iter().enumerate() {
             let actual = array[[i, 0_usize, 0_usize]];
-            eyre::ensure!(actual == p, "pixel {i} mismatch: got {actual}, expected {p}");
+            eyre::ensure!(
+                actual == p,
+                "pixel {i} mismatch: got {actual}, expected {p}"
+            );
         }
         Ok(())
     }
@@ -271,34 +284,5 @@ mod tests {
             check_one_offset(leading_pad, &pixels)
                 .unwrap_or_else(|e| panic!("leading_pad={leading_pad}: {e:?}"));
         }
-    }
-
-    /// The shared `widen_unaligned` default method must widen each
-    /// element type the way the aligned fast path does: sign-extend
-    /// signed types, zero-extend unsigned ones, pass `i32` through. The
-    /// `#18` regression test above only drives the `i32` width, so this
-    /// locks in the `size_of::<Self>()` dispatch and the sign/zero
-    /// extension for the remaining widths.
-    #[test]
-    fn widen_unaligned_widens_each_element_type() {
-        assert_eq!(
-            i16::widen_unaligned(&[0x00_u8, 0x80, 0xff, 0x7f]).expect("even length"),
-            vec![i32::from(i16::MIN), i32::from(i16::MAX)],
-        );
-        assert_eq!(
-            u16::widen_unaligned(&[0x00_u8, 0x80, 0xff, 0xff]).expect("even length"),
-            vec![0x8000_i32, 0xffff_i32],
-        );
-        assert_eq!(
-            u8::widen_unaligned(&[0x00_u8, 0x80, 0xff]).expect("any length"),
-            vec![0_i32, 128_i32, 255_i32],
-        );
-        assert_eq!(
-            i32::widen_unaligned(&[0xff_u8, 0xff, 0xff, 0xff]).expect("multiple of four"),
-            vec![-1_i32],
-        );
-        // A trailing partial element reproduces the fast path's
-        // `OutputSliceWouldHaveSlop` rejection.
-        assert!(i16::widen_unaligned(&[0x00_u8, 0x80, 0x01]).is_err());
     }
 }

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -1,6 +1,6 @@
 use super::{
     AsTransmissionElementType, ImageArray, ImageArrayRank, ImageBytesMetadata, ImageElementType,
-    TransmissionElementType, COLOUR_AXIS, IMAGE_BYTES_TYPE,
+    TransmissionElementType, WidenLeChunk, COLOUR_AXIS, IMAGE_BYTES_TYPE,
 };
 use crate::client::{Response, ResponseTransaction, ResponseWithTransaction};
 use crate::{ASCOMError, ASCOMErrorCode, ASCOMResult};
@@ -82,7 +82,9 @@ impl<'de> Deserialize<'de> for JsonImageArray {
     }
 }
 
-fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, PodCastError> {
+fn cast_raw_data<const N: usize, T: AsTransmissionElementType + WidenLeChunk<N>>(
+    data: &[u8],
+) -> Result<Vec<i32>, PodCastError> {
     // Fast path: if `data` is already aligned to `align_of::<T>()`,
     // `try_cast_slice` reinterprets in place and we iterate-and-widen
     // into the output `Vec<i32>`. This is the common case — most host
@@ -93,24 +95,22 @@ fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, 
     // from reqwest's chunked read, and its start pointer is not
     // *guaranteed* to be `align_of::<T>()`-aligned (4 bytes for
     // `i32`, 2 for `i16` / `u16`). When the fast cast fails with
-    // `TargetAlignmentGreaterAndInputNotAligned`, decode each chunk
-    // via `T::widen_from_le_chunk` straight into the output
-    // `Vec<i32>` — one pass, no intermediate aligned `Vec<T>`.
-    // Memory ceiling on the slow path is `sizeof_output` rather
-    // than `data.len() + sizeof_output`. Length-mismatch / slop
-    // errors propagate verbatim — only the alignment failure gets
-    // the unaligned fallback.
+    // `TargetAlignmentGreaterAndInputNotAligned`, split `data` into
+    // fixed-size `&[u8; N]` chunks with `as_chunks` and decode each
+    // via `T::widen_from_le_chunk` (little-endian, no per-pixel bounds
+    // check) straight into the output `Vec<i32>` — one pass, no
+    // intermediate aligned `Vec<T>`. `as_chunks` hands back the
+    // `len % N` tail as a remainder; a non-empty remainder reproduces
+    // the `OutputSliceWouldHaveSlop` guarantee. Other cast errors
+    // propagate verbatim — only the alignment failure falls back.
     match bytemuck::try_cast_slice::<u8, T>(data) {
         Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
         Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
-            let elem_size = size_of::<T>();
-            if !data.len().is_multiple_of(elem_size) {
+            let (chunks, remainder) = data.as_chunks::<N>();
+            if !remainder.is_empty() {
                 return Err(PodCastError::OutputSliceWouldHaveSlop);
             }
-            Ok(data
-                .chunks_exact(elem_size)
-                .map(T::widen_from_le_chunk)
-                .collect())
+            Ok(chunks.iter().map(T::widen_from_le_chunk).collect())
         }
         Err(other) => Err(other),
     }
@@ -168,10 +168,10 @@ impl Response for ASCOMResult<ImageArray> {
             let transmission_element_type =
                 TransmissionElementType::try_from_primitive(metadata.transmission_element_type)?;
             let data = match transmission_element_type {
-                TransmissionElementType::I16 => cast_raw_data::<i16>(raw_data),
-                TransmissionElementType::I32 => cast_raw_data::<i32>(raw_data),
-                TransmissionElementType::U8 => cast_raw_data::<u8>(raw_data),
-                TransmissionElementType::U16 => cast_raw_data::<u16>(raw_data),
+                TransmissionElementType::I16 => cast_raw_data::<2, i16>(raw_data),
+                TransmissionElementType::I32 => cast_raw_data::<4, i32>(raw_data),
+                TransmissionElementType::U8 => cast_raw_data::<1, u8>(raw_data),
+                TransmissionElementType::U16 => cast_raw_data::<2, u16>(raw_data),
             }?;
             let shape = ndarray::Ix3(
                 usize::try_from(metadata.dimension_1)?,
@@ -245,8 +245,9 @@ mod tests {
     /// `bytemuck::PodCastError::TargetAlignmentGreaterAndInputNotAligned`
     /// because both the metadata `try_from_bytes` and the pixel
     /// `try_cast_slice` require source alignment. After the fix —
-    /// using `pod_read_unaligned` and `pod_collect_to_vec` — the
-    /// parse is alignment-independent.
+    /// metadata via `pod_read_unaligned`, and pixels via an aligned
+    /// `try_cast_slice` fast path with an `as_chunks` + little-endian
+    /// `from_le_bytes` fallback — the parse is alignment-independent.
     fn check_one_offset(leading_pad: usize, pixels: &[i32]) -> eyre::Result<()> {
         let (buf, range) = imagebytes_payload_at_offset(leading_pad, pixels)?;
         let slice = &buf[range];

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -94,16 +94,16 @@ fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, 
     // *guaranteed* to be `align_of::<T>()`-aligned (4 bytes for
     // `i32`, 2 for `i16` / `u16`). When the fast cast fails with
     // `TargetAlignmentGreaterAndInputNotAligned`, hand the bytes to
-    // `T::widen_unaligned_le`, which splits `data` into fixed-size
-    // `&[u8; N]` chunks with `as_chunks` and decodes each
-    // little-endian (no per-pixel bounds check) straight into the
-    // output `Vec<i32>` — one pass, no intermediate aligned `Vec<T>`.
-    // A non-empty `as_chunks` remainder reproduces the
+    // `T::widen_unaligned`, which splits `data` into
+    // `size_of::<T>()`-wide chunks and reads each one with
+    // `bytemuck::pod_read_unaligned` straight into the output
+    // `Vec<i32>` — one pass, no intermediate aligned `Vec<T>`. A
+    // non-empty `chunks_exact` remainder reproduces the
     // `OutputSliceWouldHaveSlop` guarantee. Other cast errors
     // propagate verbatim — only the alignment failure falls back.
     match bytemuck::try_cast_slice::<u8, T>(data) {
         Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
-        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => T::widen_unaligned_le(data),
+        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => T::widen_unaligned(data),
         Err(other) => Err(other),
     }
 }
@@ -238,8 +238,8 @@ mod tests {
     /// because both the metadata `try_from_bytes` and the pixel
     /// `try_cast_slice` require source alignment. After the fix —
     /// metadata via `pod_read_unaligned`, and pixels via an aligned
-    /// `try_cast_slice` fast path with an `as_chunks` + little-endian
-    /// `from_le_bytes` fallback — the parse is alignment-independent.
+    /// `try_cast_slice` fast path with a `pod_read_unaligned`
+    /// fallback — the parse is alignment-independent.
     fn check_one_offset(leading_pad: usize, pixels: &[i32]) -> eyre::Result<()> {
         let (buf, range) = imagebytes_payload_at_offset(leading_pad, pixels)?;
         let slice = &buf[range];
@@ -271,5 +271,34 @@ mod tests {
             check_one_offset(leading_pad, &pixels)
                 .unwrap_or_else(|e| panic!("leading_pad={leading_pad}: {e:?}"));
         }
+    }
+
+    /// The shared `widen_unaligned` default method must widen each
+    /// element type the way the aligned fast path does: sign-extend
+    /// signed types, zero-extend unsigned ones, pass `i32` through. The
+    /// `#18` regression test above only drives the `i32` width, so this
+    /// locks in the `size_of::<Self>()` dispatch and the sign/zero
+    /// extension for the remaining widths.
+    #[test]
+    fn widen_unaligned_widens_each_element_type() {
+        assert_eq!(
+            i16::widen_unaligned(&[0x00_u8, 0x80, 0xff, 0x7f]).expect("even length"),
+            vec![i32::from(i16::MIN), i32::from(i16::MAX)],
+        );
+        assert_eq!(
+            u16::widen_unaligned(&[0x00_u8, 0x80, 0xff, 0xff]).expect("even length"),
+            vec![0x8000_i32, 0xffff_i32],
+        );
+        assert_eq!(
+            u8::widen_unaligned(&[0x00_u8, 0x80, 0xff]).expect("any length"),
+            vec![0_i32, 128_i32, 255_i32],
+        );
+        assert_eq!(
+            i32::widen_unaligned(&[0xff_u8, 0xff, 0xff, 0xff]).expect("multiple of four"),
+            vec![-1_i32],
+        );
+        // A trailing partial element reproduces the fast path's
+        // `OutputSliceWouldHaveSlop` rejection.
+        assert!(i16::widen_unaligned(&[0x00_u8, 0x80, 0x01]).is_err());
     }
 }

--- a/src/api/camera/image_array/client.rs
+++ b/src/api/camera/image_array/client.rs
@@ -1,6 +1,6 @@
 use super::{
     AsTransmissionElementType, ImageArray, ImageArrayRank, ImageBytesMetadata, ImageElementType,
-    TransmissionElementType, WidenLeChunk, COLOUR_AXIS, IMAGE_BYTES_TYPE,
+    TransmissionElementType, COLOUR_AXIS, IMAGE_BYTES_TYPE,
 };
 use crate::client::{Response, ResponseTransaction, ResponseWithTransaction};
 use crate::{ASCOMError, ASCOMErrorCode, ASCOMResult};
@@ -82,9 +82,7 @@ impl<'de> Deserialize<'de> for JsonImageArray {
     }
 }
 
-fn cast_raw_data<const N: usize, T: AsTransmissionElementType + WidenLeChunk<N>>(
-    data: &[u8],
-) -> Result<Vec<i32>, PodCastError> {
+fn cast_raw_data<T: AsTransmissionElementType>(data: &[u8]) -> Result<Vec<i32>, PodCastError> {
     // Fast path: if `data` is already aligned to `align_of::<T>()`,
     // `try_cast_slice` reinterprets in place and we iterate-and-widen
     // into the output `Vec<i32>`. This is the common case — most host
@@ -95,23 +93,17 @@ fn cast_raw_data<const N: usize, T: AsTransmissionElementType + WidenLeChunk<N>>
     // from reqwest's chunked read, and its start pointer is not
     // *guaranteed* to be `align_of::<T>()`-aligned (4 bytes for
     // `i32`, 2 for `i16` / `u16`). When the fast cast fails with
-    // `TargetAlignmentGreaterAndInputNotAligned`, split `data` into
-    // fixed-size `&[u8; N]` chunks with `as_chunks` and decode each
-    // via `T::widen_from_le_chunk` (little-endian, no per-pixel bounds
-    // check) straight into the output `Vec<i32>` — one pass, no
-    // intermediate aligned `Vec<T>`. `as_chunks` hands back the
-    // `len % N` tail as a remainder; a non-empty remainder reproduces
-    // the `OutputSliceWouldHaveSlop` guarantee. Other cast errors
+    // `TargetAlignmentGreaterAndInputNotAligned`, hand the bytes to
+    // `T::widen_unaligned_le`, which splits `data` into fixed-size
+    // `&[u8; N]` chunks with `as_chunks` and decodes each
+    // little-endian (no per-pixel bounds check) straight into the
+    // output `Vec<i32>` — one pass, no intermediate aligned `Vec<T>`.
+    // A non-empty `as_chunks` remainder reproduces the
+    // `OutputSliceWouldHaveSlop` guarantee. Other cast errors
     // propagate verbatim — only the alignment failure falls back.
     match bytemuck::try_cast_slice::<u8, T>(data) {
         Ok(aligned) => Ok(aligned.iter().copied().map(T::into).collect()),
-        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
-            let (chunks, remainder) = data.as_chunks::<N>();
-            if !remainder.is_empty() {
-                return Err(PodCastError::OutputSliceWouldHaveSlop);
-            }
-            Ok(chunks.iter().map(T::widen_from_le_chunk).collect())
-        }
+        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => T::widen_unaligned_le(data),
         Err(other) => Err(other),
     }
 }
@@ -168,10 +160,10 @@ impl Response for ASCOMResult<ImageArray> {
             let transmission_element_type =
                 TransmissionElementType::try_from_primitive(metadata.transmission_element_type)?;
             let data = match transmission_element_type {
-                TransmissionElementType::I16 => cast_raw_data::<2, i16>(raw_data),
-                TransmissionElementType::I32 => cast_raw_data::<4, i32>(raw_data),
-                TransmissionElementType::U8 => cast_raw_data::<1, u8>(raw_data),
-                TransmissionElementType::U16 => cast_raw_data::<2, u16>(raw_data),
+                TransmissionElementType::I16 => cast_raw_data::<i16>(raw_data),
+                TransmissionElementType::I32 => cast_raw_data::<i32>(raw_data),
+                TransmissionElementType::U8 => cast_raw_data::<u8>(raw_data),
+                TransmissionElementType::U16 => cast_raw_data::<u16>(raw_data),
             }?;
             let shape = ndarray::Ix3(
                 usize::try_from(metadata.dimension_1)?,

--- a/src/api/camera/image_array/mod.rs
+++ b/src/api/camera/image_array/mod.rs
@@ -64,22 +64,53 @@ pub(crate) enum ImageElementType {
 
 trait AsTransmissionElementType: 'static + Into<i32> + AnyBitPattern {
     const TYPE: TransmissionElementType;
+
+    /// Read a single little-endian `Self` from a
+    /// `size_of::<Self>()`-byte chunk and widen to `i32`. Used by
+    /// the unaligned-input slow path of `cast_raw_data` (see
+    /// `image_array/client.rs`) so the conversion can go from
+    /// response bytes straight into `Vec<i32>` in one pass without
+    /// staging through an intermediate aligned `Vec<Self>`.
+    /// Callers must feed exactly `size_of::<Self>()` bytes (e.g. via
+    /// `data.chunks_exact(size_of::<Self>())`).
+    fn widen_from_le_chunk(chunk: &[u8]) -> i32;
 }
 
 impl AsTransmissionElementType for i16 {
     const TYPE: TransmissionElementType = TransmissionElementType::I16;
+
+    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
+        i32::from(Self::from_le_bytes([chunk[0_usize], chunk[1_usize]]))
+    }
 }
 
 impl AsTransmissionElementType for i32 {
     const TYPE: TransmissionElementType = TransmissionElementType::I32;
+
+    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
+        Self::from_le_bytes([
+            chunk[0_usize],
+            chunk[1_usize],
+            chunk[2_usize],
+            chunk[3_usize],
+        ])
+    }
 }
 
 impl AsTransmissionElementType for u16 {
     const TYPE: TransmissionElementType = TransmissionElementType::U16;
+
+    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
+        i32::from(Self::from_le_bytes([chunk[0_usize], chunk[1_usize]]))
+    }
 }
 
 impl AsTransmissionElementType for u8 {
     const TYPE: TransmissionElementType = TransmissionElementType::U8;
+
+    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
+        i32::from(chunk[0_usize])
+    }
 }
 
 /// Image array.

--- a/src/api/camera/image_array/mod.rs
+++ b/src/api/camera/image_array/mod.rs
@@ -62,82 +62,39 @@ pub(crate) enum ImageElementType {
     I32 = 2,
 }
 
-trait AsTransmissionElementType: 'static + Into<i32> + AnyBitPattern {
+trait AsTransmissionElementType: Into<i32> + AnyBitPattern {
     const TYPE: TransmissionElementType;
 
-    /// Decode an unaligned little-endian byte slice into widened `i32`
-    /// pixels. Used by the unaligned-input slow path of `cast_raw_data`
-    /// (see `image_array/client.rs`) when `bytemuck::try_cast_slice`
-    /// can't reinterpret in place. Each impl splits `data` with
-    /// `slice::as_chunks::<N>()`, hard-coding `N` to its own byte width
-    /// (`i16` / `u16` => 2, `i32` => 4, `u8` => 1) so the chunk size is
-    /// tied to the element type at compile time and the per-pixel
-    /// `from_le_bytes` conversions operate on `&[u8; N]` arrays with no
-    /// bounds checks. A non-empty `as_chunks` remainder reproduces the
-    /// `OutputSliceWouldHaveSlop` guarantee of the fast path.
+    /// Decode an unaligned response buffer into widened `i32` pixels.
+    /// Used by the unaligned-input slow path of `cast_raw_data` (see
+    /// `image_array/client.rs`) when `bytemuck::try_cast_slice` can't
+    /// reinterpret in place.
     #[cfg(feature = "client")]
-    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError>;
+    fn widen_unaligned(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
+        let chunks = data.chunks_exact(size_of::<Self>());
+        if !chunks.remainder().is_empty() {
+            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
+        }
+        Ok(chunks
+            .map(|c| bytemuck::pod_read_unaligned::<Self>(c).into())
+            .collect())
+    }
 }
 
 impl AsTransmissionElementType for i16 {
     const TYPE: TransmissionElementType = TransmissionElementType::I16;
-
-    #[cfg(feature = "client")]
-    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
-        let (chunks, remainder) = data.as_chunks::<2>();
-        if !remainder.is_empty() {
-            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
-        }
-        Ok(chunks
-            .iter()
-            .map(|c| i32::from(Self::from_le_bytes(*c)))
-            .collect())
-    }
 }
 
 impl AsTransmissionElementType for i32 {
     const TYPE: TransmissionElementType = TransmissionElementType::I32;
-
-    #[cfg(feature = "client")]
-    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
-        let (chunks, remainder) = data.as_chunks::<4>();
-        if !remainder.is_empty() {
-            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
-        }
-        Ok(chunks.iter().map(|c| Self::from_le_bytes(*c)).collect())
-    }
 }
 
 impl AsTransmissionElementType for u16 {
     const TYPE: TransmissionElementType = TransmissionElementType::U16;
-
-    #[cfg(feature = "client")]
-    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
-        let (chunks, remainder) = data.as_chunks::<2>();
-        if !remainder.is_empty() {
-            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
-        }
-        Ok(chunks
-            .iter()
-            .map(|c| i32::from(Self::from_le_bytes(*c)))
-            .collect())
-    }
 }
 
 impl AsTransmissionElementType for u8 {
     const TYPE: TransmissionElementType = TransmissionElementType::U8;
-
-    #[cfg(feature = "client")]
-    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
-        let (chunks, remainder) = data.as_chunks::<1>();
-        if !remainder.is_empty() {
-            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
-        }
-        Ok(chunks
-            .iter()
-            .map(|c| i32::from(Self::from_le_bytes(*c)))
-            .collect())
-    }
 }
 
 /// Image array.

--- a/src/api/camera/image_array/mod.rs
+++ b/src/api/camera/image_array/mod.rs
@@ -64,52 +64,62 @@ pub(crate) enum ImageElementType {
 
 trait AsTransmissionElementType: 'static + Into<i32> + AnyBitPattern {
     const TYPE: TransmissionElementType;
+}
 
-    /// Read a single little-endian `Self` from a
-    /// `size_of::<Self>()`-byte chunk and widen to `i32`. Used by
-    /// the unaligned-input slow path of `cast_raw_data` (see
-    /// `image_array/client.rs`) so the conversion can go from
-    /// response bytes straight into `Vec<i32>` in one pass without
-    /// staging through an intermediate aligned `Vec<Self>`.
-    /// Callers must feed exactly `size_of::<Self>()` bytes (e.g. via
-    /// `data.chunks_exact(size_of::<Self>())`).
-    fn widen_from_le_chunk(chunk: &[u8]) -> i32;
+/// Decode one little-endian element from a fixed-size `&[u8; N]` chunk
+/// and widen it to `i32`. The const `N` ties the byte-chunk width to
+/// the element type at the type level (`i16` / `u16` => 2, `i32` => 4,
+/// `u8` => 1), so a chunk width that disagrees with the element is a
+/// compile error and the per-pixel conversions carry no bounds checks.
+/// Used by the unaligned-input slow path of `cast_raw_data` (see
+/// `image_array/client.rs`); the aligned fast path still reinterprets
+/// in place via `bytemuck::try_cast_slice`.
+#[cfg(feature = "client")]
+trait WidenLeChunk<const N: usize> {
+    fn widen_from_le_chunk(chunk: &[u8; N]) -> i32;
 }
 
 impl AsTransmissionElementType for i16 {
     const TYPE: TransmissionElementType = TransmissionElementType::I16;
+}
 
-    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
-        i32::from(Self::from_le_bytes([chunk[0_usize], chunk[1_usize]]))
+#[cfg(feature = "client")]
+impl WidenLeChunk<2> for i16 {
+    fn widen_from_le_chunk(chunk: &[u8; 2]) -> i32 {
+        i32::from(Self::from_le_bytes(*chunk))
     }
 }
 
 impl AsTransmissionElementType for i32 {
     const TYPE: TransmissionElementType = TransmissionElementType::I32;
+}
 
-    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
-        Self::from_le_bytes([
-            chunk[0_usize],
-            chunk[1_usize],
-            chunk[2_usize],
-            chunk[3_usize],
-        ])
+#[cfg(feature = "client")]
+impl WidenLeChunk<4> for i32 {
+    fn widen_from_le_chunk(chunk: &[u8; 4]) -> i32 {
+        Self::from_le_bytes(*chunk)
     }
 }
 
 impl AsTransmissionElementType for u16 {
     const TYPE: TransmissionElementType = TransmissionElementType::U16;
+}
 
-    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
-        i32::from(Self::from_le_bytes([chunk[0_usize], chunk[1_usize]]))
+#[cfg(feature = "client")]
+impl WidenLeChunk<2> for u16 {
+    fn widen_from_le_chunk(chunk: &[u8; 2]) -> i32 {
+        i32::from(Self::from_le_bytes(*chunk))
     }
 }
 
 impl AsTransmissionElementType for u8 {
     const TYPE: TransmissionElementType = TransmissionElementType::U8;
+}
 
-    fn widen_from_le_chunk(chunk: &[u8]) -> i32 {
-        i32::from(chunk[0_usize])
+#[cfg(feature = "client")]
+impl WidenLeChunk<1> for u8 {
+    fn widen_from_le_chunk(chunk: &[u8; 1]) -> i32 {
+        i32::from(Self::from_le_bytes(*chunk))
     }
 }
 

--- a/src/api/camera/image_array/mod.rs
+++ b/src/api/camera/image_array/mod.rs
@@ -64,62 +64,79 @@ pub(crate) enum ImageElementType {
 
 trait AsTransmissionElementType: 'static + Into<i32> + AnyBitPattern {
     const TYPE: TransmissionElementType;
-}
 
-/// Decode one little-endian element from a fixed-size `&[u8; N]` chunk
-/// and widen it to `i32`. The const `N` ties the byte-chunk width to
-/// the element type at the type level (`i16` / `u16` => 2, `i32` => 4,
-/// `u8` => 1), so a chunk width that disagrees with the element is a
-/// compile error and the per-pixel conversions carry no bounds checks.
-/// Used by the unaligned-input slow path of `cast_raw_data` (see
-/// `image_array/client.rs`); the aligned fast path still reinterprets
-/// in place via `bytemuck::try_cast_slice`.
-#[cfg(feature = "client")]
-trait WidenLeChunk<const N: usize> {
-    fn widen_from_le_chunk(chunk: &[u8; N]) -> i32;
+    /// Decode an unaligned little-endian byte slice into widened `i32`
+    /// pixels. Used by the unaligned-input slow path of `cast_raw_data`
+    /// (see `image_array/client.rs`) when `bytemuck::try_cast_slice`
+    /// can't reinterpret in place. Each impl splits `data` with
+    /// `slice::as_chunks::<N>()`, hard-coding `N` to its own byte width
+    /// (`i16` / `u16` => 2, `i32` => 4, `u8` => 1) so the chunk size is
+    /// tied to the element type at compile time and the per-pixel
+    /// `from_le_bytes` conversions operate on `&[u8; N]` arrays with no
+    /// bounds checks. A non-empty `as_chunks` remainder reproduces the
+    /// `OutputSliceWouldHaveSlop` guarantee of the fast path.
+    #[cfg(feature = "client")]
+    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError>;
 }
 
 impl AsTransmissionElementType for i16 {
     const TYPE: TransmissionElementType = TransmissionElementType::I16;
-}
 
-#[cfg(feature = "client")]
-impl WidenLeChunk<2> for i16 {
-    fn widen_from_le_chunk(chunk: &[u8; 2]) -> i32 {
-        i32::from(Self::from_le_bytes(*chunk))
+    #[cfg(feature = "client")]
+    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
+        let (chunks, remainder) = data.as_chunks::<2>();
+        if !remainder.is_empty() {
+            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
+        }
+        Ok(chunks
+            .iter()
+            .map(|c| i32::from(Self::from_le_bytes(*c)))
+            .collect())
     }
 }
 
 impl AsTransmissionElementType for i32 {
     const TYPE: TransmissionElementType = TransmissionElementType::I32;
-}
 
-#[cfg(feature = "client")]
-impl WidenLeChunk<4> for i32 {
-    fn widen_from_le_chunk(chunk: &[u8; 4]) -> i32 {
-        Self::from_le_bytes(*chunk)
+    #[cfg(feature = "client")]
+    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
+        let (chunks, remainder) = data.as_chunks::<4>();
+        if !remainder.is_empty() {
+            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
+        }
+        Ok(chunks.iter().map(|c| Self::from_le_bytes(*c)).collect())
     }
 }
 
 impl AsTransmissionElementType for u16 {
     const TYPE: TransmissionElementType = TransmissionElementType::U16;
-}
 
-#[cfg(feature = "client")]
-impl WidenLeChunk<2> for u16 {
-    fn widen_from_le_chunk(chunk: &[u8; 2]) -> i32 {
-        i32::from(Self::from_le_bytes(*chunk))
+    #[cfg(feature = "client")]
+    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
+        let (chunks, remainder) = data.as_chunks::<2>();
+        if !remainder.is_empty() {
+            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
+        }
+        Ok(chunks
+            .iter()
+            .map(|c| i32::from(Self::from_le_bytes(*c)))
+            .collect())
     }
 }
 
 impl AsTransmissionElementType for u8 {
     const TYPE: TransmissionElementType = TransmissionElementType::U8;
-}
 
-#[cfg(feature = "client")]
-impl WidenLeChunk<1> for u8 {
-    fn widen_from_le_chunk(chunk: &[u8; 1]) -> i32 {
-        i32::from(Self::from_le_bytes(*chunk))
+    #[cfg(feature = "client")]
+    fn widen_unaligned_le(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
+        let (chunks, remainder) = data.as_chunks::<1>();
+        if !remainder.is_empty() {
+            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
+        }
+        Ok(chunks
+            .iter()
+            .map(|c| i32::from(Self::from_le_bytes(*c)))
+            .collect())
     }
 }
 

--- a/src/api/camera/image_array/mod.rs
+++ b/src/api/camera/image_array/mod.rs
@@ -64,37 +64,28 @@ pub(crate) enum ImageElementType {
 
 trait AsTransmissionElementType: Into<i32> + AnyBitPattern {
     const TYPE: TransmissionElementType;
-
-    /// Decode an unaligned response buffer into widened `i32` pixels.
-    /// Used by the unaligned-input slow path of `cast_raw_data` (see
-    /// `image_array/client.rs`) when `bytemuck::try_cast_slice` can't
-    /// reinterpret in place.
-    #[cfg(feature = "client")]
-    fn widen_unaligned(data: &[u8]) -> Result<Vec<i32>, bytemuck::PodCastError> {
-        let chunks = data.chunks_exact(size_of::<Self>());
-        if !chunks.remainder().is_empty() {
-            return Err(bytemuck::PodCastError::OutputSliceWouldHaveSlop);
-        }
-        Ok(chunks
-            .map(|c| bytemuck::pod_read_unaligned::<Self>(c).into())
-            .collect())
-    }
+    type Bytes: Pod;
 }
 
 impl AsTransmissionElementType for i16 {
     const TYPE: TransmissionElementType = TransmissionElementType::I16;
+    type Bytes = [u8; size_of::<Self>()];
 }
 
 impl AsTransmissionElementType for i32 {
     const TYPE: TransmissionElementType = TransmissionElementType::I32;
+    type Bytes = [u8; size_of::<Self>()];
 }
 
 impl AsTransmissionElementType for u16 {
     const TYPE: TransmissionElementType = TransmissionElementType::U16;
+    type Bytes = [u8; size_of::<Self>()];
 }
 
 impl AsTransmissionElementType for u8 {
     const TYPE: TransmissionElementType = TransmissionElementType::U8;
+    #[expect(clippy::use_self)]
+    type Bytes = [u8; size_of::<Self>()];
 }
 
 /// Image array.


### PR DESCRIPTION
## Summary

Both `ImageBytes` decode call sites in `src/api/camera/image_array/` handle an HTTP response body buffer (a `bytes::Bytes` slice from reqwest's chunked read) that is not guaranteed to be aligned to the element type. The OS allocator usually delivers an aligned buffer, but not always — particularly on macOS under bazel's test runner — which caused intermittent `ASCOM error UNSPECIFIED: TargetAlignmentGreaterAndInputNotAligned` panics.

- **Metadata:** decoded with `bytemuck::pod_read_unaligned` (reads via `ptr::read_unaligned`, works for any pointer alignment).
- **Pixels (`cast_raw_data`):** uses the zero-copy `bytemuck::try_cast_slice` fast path when the buffer is aligned. On `TargetAlignmentGreaterAndInputNotAligned` it falls back to `T::widen_unaligned_le`, which splits the payload into fixed-size `&[u8; N]` chunks with `<[u8]>::as_chunks::<N>()` and decodes each little-endian element via `from_le_bytes` straight into the output `Vec<i32>` — one pass, no intermediate `Vec<T>`. A non-empty `as_chunks` remainder yields `OutputSliceWouldHaveSlop`; any other `PodCastError` propagates verbatim.
- `widen_unaligned_le` is a method on the `AsTransmissionElementType` trait, gated behind `feature = "client"`. Each impl (`i16` / `u16` → 2, `i32` → 4, `u8` → 1) hard-codes the `as_chunks::<N>` width, so the byte-chunk size is tied to the element type at compile time and the per-pixel conversions carry no bounds checks.
- `from_le_bytes` is endianness-correct; the crate already `compile_error!`s on big-endian targets.
- A regression test exercises leading-pad offsets `0..4` within the source `Vec<u8>` so at least three iterations place the body slice on a non-aligned start.

No public API change.

Fixes #18.

## Test plan
- [x] `cargo clippy --locked --all --all-targets --features <network>,<device>` with `RUSTFLAGS=-D warnings` — clean across the CI matrix (`{client,server} × {camera,telescope,focuser}` plus `client,server` × `all-devices`).
- [x] `cargo test --locked --features client,server,all-devices,test --lib -- discovery::tests::test_unspecified_v4_only discovery::tests::test_loopback_v6_only` — pass.
- [x] `cargo test --all-features --lib api::camera::image_array` — regression test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
